### PR TITLE
Hotfix: vite 버전을 다운그레이드한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tslib": "^2.6.3",
     "turbo": "^2.1.1",
     "typescript": "5.5.3",
-    "vite": "5.4.3",
+    "vite": "5.3.3",
     "overlay-kit": "^1.4.1"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: 5.5.3
         version: 5.5.3
       vite:
-        specifier: 5.4.3
-        version: 5.4.3(@types/node@20.14.15)
+        specifier: 5.3.3
+        version: 5.3.3(@types/node@20.14.15)
 
   chrome-extension:
     dependencies:
@@ -132,7 +132,7 @@ importers:
         version: link:../packages/vite-config
       '@laynezh/vite-plugin-lib-assets':
         specifier: ^0.5.23
-        version: 0.5.23(vite@5.4.3)
+        version: 0.5.23(vite@5.3.3)
       '@types/ws':
         specifier: ^8.5.11
         version: 8.5.12
@@ -229,7 +229,7 @@ importers:
         version: link:../tsconfig
       '@vitejs/plugin-react-swc':
         specifier: ^3.6.0
-        version: 3.7.0(vite@5.4.3)
+        version: 3.7.0(vite@5.3.3)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -329,7 +329,7 @@ importers:
         version: 0.5.14(tailwindcss@3.4.10)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@5.4.3)
+        version: 4.3.1(vite@5.3.3)
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.3.5)(react@18.3.1)
@@ -351,7 +351,7 @@ importers:
         version: link:../../packages/vite-config
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(typescript@5.5.3)(vite@5.4.3)
+        version: 4.2.0(typescript@5.5.3)(vite@5.3.3)
 
   pages/devtools:
     dependencies:
@@ -1242,7 +1242,7 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.0
     dev: true
 
-  /@laynezh/vite-plugin-lib-assets@0.5.23(vite@5.4.3):
+  /@laynezh/vite-plugin-lib-assets@0.5.23(vite@5.3.3):
     resolution: {integrity: sha512-17df7hIpAM/wO+2z6cI7OIBuoJCHz1pRtY5A6g+R72KVKhjp8KrqCObDapuWEGY+RliSTBjvwi6rfQfFj/1JKg==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
@@ -1251,7 +1251,7 @@ packages:
       loader-utils: 3.3.1
       mrmime: 1.0.1
       semver: 7.6.3
-      vite: 5.4.3(@types/node@20.14.15)
+      vite: 5.3.3(@types/node@20.14.15)
     dev: true
 
   /@next/env@14.2.7:
@@ -2160,18 +2160,18 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitejs/plugin-react-swc@3.7.0(vite@5.4.3):
+  /@vitejs/plugin-react-swc@3.7.0(vite@5.3.3):
     resolution: {integrity: sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==}
     peerDependencies:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.7.10
-      vite: 5.4.3(@types/node@20.14.15)
+      vite: 5.3.3(@types/node@20.14.15)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@vitejs/plugin-react@4.3.1(vite@5.4.3):
+  /@vitejs/plugin-react@4.3.1(vite@5.3.3):
     resolution: {integrity: sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -2182,7 +2182,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.3(@types/node@20.14.15)
+      vite: 5.3.3(@types/node@20.14.15)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6681,7 +6681,7 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
-  /vite-plugin-svgr@4.2.0(typescript@5.5.3)(vite@5.4.3):
+  /vite-plugin-svgr@4.2.0(typescript@5.5.3)(vite@5.3.3):
     resolution: {integrity: sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==}
     peerDependencies:
       vite: ^2.6.0 || 3 || 4 || 5
@@ -6689,15 +6689,15 @@ packages:
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
       '@svgr/core': 8.1.0(typescript@5.5.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      vite: 5.4.3(@types/node@20.14.15)
+      vite: 5.3.3(@types/node@20.14.15)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
     dev: true
 
-  /vite@5.4.3(@types/node@20.14.15):
-    resolution: {integrity: sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==}
+  /vite@5.3.3(@types/node@20.14.15):
+    resolution: {integrity: sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6705,7 +6705,6 @@ packages:
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
-      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
       terser: ^5.4.0
@@ -6717,8 +6716,6 @@ packages:
       lightningcss:
         optional: true
       sass:
-        optional: true
-      sass-embedded:
         optional: true
       stylus:
         optional: true


### PR DESCRIPTION
# PR의 목적
빌드 이슈를 해결합니다.
![image](https://github.com/user-attachments/assets/93547ffa-b2db-4bec-ae1c-ade7f8912d96)

# 작업 목록
1주일 전, dependabot이 vite 버전 업그레이드를 권장하여 업그레이드했던 것이 원인이었습니다. 이에 따라 기존 버전인 4.3.3으로 다운그레이드합니다.
