### PR TITLE
Hotfix: New Tab 제목의 글자 넘침을 방지한다

### DIFF
--- a/pages/new-tab/src/components/MemoTable.tsx
+++ b/pages/new-tab/src/components/MemoTable.tsx
@@ -39,7 +39,12 @@ export default function MemoTable() {
             <tr key={memo.url} className="hover">
               <th className="text-center">{index + 1}</th>
               <td>
-                <a href={memo.url} target="_blank" rel="noreferrer" className="tooltip text-start" data-tip={memo.url}>
+                <a
+                  href={memo.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="tooltip line-clamp-2 text-start max-w-[18rem]"
+                  data-tip={memo.url}>
                   {memo.title}
                 </a>
               </td>


### PR DESCRIPTION
# PR의 목적
![image](https://github.com/user-attachments/assets/9bcfc69b-7778-4042-876a-74eb04846850)

제목의 글씨가 길 경우 위와 같은 이슈가 있어 이를 해결하였습니다.

# 작업 목록
tailwindcss에서 [`line-clamp-2`](https://tailwindcss.com/docs/line-clamp)옵션은 아래 css속성과 같습니다.

```css
overflow: hidden; // 넘칠 경우 숨긴다.
display: -webkit-box; // WebKit 기반 브라우저(Chrome, Safari 등)에서 사용되는 flexbox의 구버전
-webkit-box-orient: vertical; // 내부 아이템들이 세로 방향으로 쌓이도록 설정
-webkit-line-clamp: 2; // 텍스트의 라인 수를 2로 제한
```

즉, 제목이 넘넘칠 경우, 두 줄까지 보여지고 그 이후로는 `...`처리가 됩니다.

## After
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/d3984eb9-15f5-470c-88b8-5b0eb00bc3da">


