### PR TITLE
Hofix: openai 429 에러를 해결한다

### DIFF
--- a/packages/shared/lib/hooks/useFetch.ts
+++ b/packages/shared/lib/hooks/useFetch.ts
@@ -50,7 +50,8 @@ export default function useFetch<TData>({ fetchFn, defaultValue }: UseFetchProps
     return () => {
       if (abortControllerRef.current) abortControllerRef.current.abort();
     };
-  }, [fetch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (status === 'rejected' && error) throw error;
   return { data, error, refetch: fetch, status, isLoading: status === 'loading' };


### PR DESCRIPTION
# PR의 목적
![image](https://github.com/user-attachments/assets/f5f118c8-a66f-416c-87e9-c13d85fb8653)
![image](https://github.com/user-attachments/assets/899d4832-fece-47b5-a2ed-e5de29fee330)


openai의 429에러를 해결합니다.

# 작업 목록
원인은 useEffect 내 의존성 배열에 fetch함수를 넣어 fetch함수 선언 -> useEffect 내부 실행 -> fetch 함수 선언 ..이 반복되던 것이었습니다. 이에 따라 useEffect 내 의존성 배열에서 fetch함수를 제거하였습니다.
