### PR TITLE
Hotfix: manifest의 description을 추가하여 개요 이슈를 해결한다

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -15,16 +15,14 @@ const sidePanelConfig = {
  * After changing, please reload the extension at `chrome://extensions`
  * @type {chrome.runtime.ManifestV3}
  */
+
 const manifest = deepmerge(
   {
     manifest_version: 3,
-    /**
-     * if you want to support multiple languages, you can use the following reference
-     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization
-     */
-    name: 'Web Memo',
-    default_locale: 'en',
+    name: '__MSG_extensionName__',
     version: packageJson.version,
+    description: '__MSG_extensionDescription__',
+    default_locale: 'en',
     permissions: ['sidePanel', 'storage', 'tabs'],
     host_permissions: ['<all_urls>'],
     options_page: 'options/index.html',


### PR DESCRIPTION
# PR의 목적
개요의 글이 깨지는 이슈를 해결합니다.

![image](https://github.com/user-attachments/assets/fa9c73a3-2096-4d1a-9dd4-01cc1fcda6ab)


# 작업 목록
![image](https://github.com/user-attachments/assets/07367ae8-ef65-4234-9f5c-b09e291abbd6)

며칠의 고민과 방법을 강구했지만, 문의를 통해 manifest > description이 원인이라는 것을 끝내 알게되었습니다. 자세한 디버깅 내용은 노션 링크 참고 부탁드립니다.