### PR TITLE
Hotfix: Sentry 에러를 고친다

### DIFF
--- a/packages/shared/src/utils/extension/getIsProduction.ts
+++ b/packages/shared/src/utils/extension/getIsProduction.ts
@@ -1,4 +1,4 @@
 export const getIsProduction = async () => {
   const self = await chrome.management.getSelf();
-  return self.installType !== 'developement';
+  return self.installType !== 'development';
 };


### PR DESCRIPTION
# 작업 목록
`development`의 오타를 수정합니다.
