### PR TITLE
Refactor: useMemoQuery로 리팩토링

### DIFF
--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { default as useMemoPatchMutation } from './useMemoPatchMutation';
 export { default as useMemoListQuery } from './useMemoListQuery';
 export { default as useSupabaseClient } from './useSupabaseClient';
 export { default as useSupabaseUser } from './useSupabaseUser';
+export { default as useMemoQuery } from './useMemoQuery';

--- a/packages/shared/src/hooks/useMemoQuery.ts
+++ b/packages/shared/src/hooks/useMemoQuery.ts
@@ -1,0 +1,21 @@
+import { queryKeys } from '@src/constants';
+import { MemoSupabaseClient, MemoSupabaseResponse } from '@src/types';
+import { getMemoSupabase } from '@src/utils';
+import { useQuery } from '@tanstack/react-query';
+
+interface UseMemoQueryProps {
+  supabaseClient: MemoSupabaseClient;
+  url?: string;
+}
+
+export default function useMemoQuery({ supabaseClient, url }: UseMemoQueryProps) {
+  return useQuery({
+    queryFn: getMemoSupabase.bind(null, supabaseClient),
+    queryKey: queryKeys.memoList(),
+    enabled: !!supabaseClient,
+    select: ({ data: memoList }: MemoSupabaseResponse) => {
+      const currentMemo = memoList?.find(memo => memo.url === url);
+      return currentMemo;
+    },
+  });
+}

--- a/pages/side-panel/src/components/MemoForm.tsx
+++ b/pages/side-panel/src/components/MemoForm.tsx
@@ -16,7 +16,6 @@ import {
   GetFormattedMemoProps,
   getSupabaseClient,
   responseRefetchTheMemoList,
-  responseUpdateSidePanel,
 } from '@extension/shared/utils/extension';
 import { cn, Toast } from '@extension/ui';
 import withAuthentication from '@src/hoc/withAuthentication';
@@ -55,6 +54,8 @@ function MemoForm() {
   });
 
   const saveMemo = async ({ memo, category }: GetFormattedMemoProps) => {
+    if (memo === '') return;
+
     const currentMemo = memoList?.data?.find(memo => memo.url === formatUrl(tab.url));
     const formattedMemo = await getFormattedMemo({ category, memo });
 
@@ -62,12 +63,6 @@ function MemoForm() {
     else mutateMemoPost(formattedMemo);
   };
 
-  useDidMount(() =>
-    responseUpdateSidePanel(() => {
-      setIsSaved(true);
-      abortThrottle();
-    }),
-  );
   useDidMount(() => {
     responseRefetchTheMemoList(refetchMemoList);
   });


### PR DESCRIPTION
# PR 목적
: 현재 페이지의 메모를 가져오는 로직을 `useMemoQuery`에 응집합니다.

# PR 체크리스트
- [x] CI(type, lint, build)를 체크하였나요?
- [ ] I18n으로 번역을 수행하였나요?
- [x] 15분 이내에 읽을 수 있는 크기의 PR을 작성하였나요?
- [x] 코드를 한 번씩 읽어보았나요? 가독성이 괜찮았나요? 추가 설명이 필요한 부분에 주석 및 코멘트를 달았나요?