### PR TITLE
Feature: 설정 - 카테고리, 가이드 다시 시작 기능

### DIFF
--- a/packages/shared/src/constants/Supabase.ts
+++ b/packages/shared/src/constants/Supabase.ts
@@ -3,4 +3,5 @@ export const SUPABASE = {
   testEmail: 'test@test.com',
   testPassword: 'abcd1234',
   schemaMemo: 'memo',
+  schemaCategory: 'category',
 } as const;

--- a/packages/shared/src/hooks/supabase/index.ts
+++ b/packages/shared/src/hooks/supabase/index.ts
@@ -1,5 +1,8 @@
+export { default as useCategoryDeleteMutation } from './useCategoryDeleteMutation';
+export { default as useCategoryPatchMutation } from './useCategoryPatchMutation';
 export { default as useCategoryPostMutation } from './useCategoryPostMutation';
 export { default as useCategoryQuery } from './useCategoryQuery';
+export { default as useCategoryUpsertMutation } from './useCategoryUpsertMutation';
 export { default as useMemoPatchMutation } from './useMemoPatchMutation';
 export { default as useMemoPostMutation } from './useMemoPostMutation';
 export { default as useMemoQuery } from './useMemoQuery';

--- a/packages/shared/src/hooks/supabase/useCategoryDeleteMutation.ts
+++ b/packages/shared/src/hooks/supabase/useCategoryDeleteMutation.ts
@@ -1,0 +1,19 @@
+import { CategoryRow, MemoSupabaseClient } from '@src/types';
+import { deleteCategory } from '@src/utils';
+import { useMutation } from '@tanstack/react-query';
+
+type MutationVariables = {
+  id: CategoryRow['id'];
+};
+type MutationData = Awaited<ReturnType<typeof deleteCategory>>;
+type MutationError = Error;
+
+interface UseCategoryDeleteMutationProps {
+  supabaseClient: MemoSupabaseClient;
+}
+
+export default function useCategoryDeleteMutation({ supabaseClient }: UseCategoryDeleteMutationProps) {
+  return useMutation<MutationData, MutationError, MutationVariables>({
+    mutationFn: ({ id }) => deleteCategory(supabaseClient, id),
+  });
+}

--- a/packages/shared/src/hooks/supabase/useCategoryPatchMutation.ts
+++ b/packages/shared/src/hooks/supabase/useCategoryPatchMutation.ts
@@ -1,0 +1,20 @@
+import { CategoryRow, CategoryTable, MemoSupabaseClient } from '@src/types';
+import { updateCategory } from '@src/utils';
+import { useMutation } from '@tanstack/react-query';
+
+type MutationVariables = {
+  id: CategoryRow['id'];
+  categoryRequest: CategoryTable['Update'];
+};
+type MutationData = Awaited<ReturnType<typeof updateCategory>>;
+type MutationError = Error;
+
+interface UseCategoryPatchMutationProps {
+  supabaseClient: MemoSupabaseClient;
+}
+
+export default function useCategoryPatchMutation({ supabaseClient }: UseCategoryPatchMutationProps) {
+  return useMutation<MutationData, MutationError, MutationVariables>({
+    mutationFn: ({ id, categoryRequest }) => updateCategory(supabaseClient, id, categoryRequest),
+  });
+}

--- a/packages/shared/src/hooks/supabase/useCategoryQuery.ts
+++ b/packages/shared/src/hooks/supabase/useCategoryQuery.ts
@@ -1,17 +1,16 @@
 import { QUERY_KEY } from '@src/constants';
 import { MemoSupabaseClient } from '@src/types';
 import { getCategories } from '@src/utils';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 interface UseCategoryQueryProps {
   supabaseClient: MemoSupabaseClient;
 }
 
 export default function useCategoryQuery({ supabaseClient }: UseCategoryQueryProps) {
-  const query = useQuery({
+  const query = useSuspenseQuery({
     queryFn: () => getCategories(supabaseClient),
     queryKey: QUERY_KEY.category(),
-    enabled: !!supabaseClient,
   });
 
   return {

--- a/packages/shared/src/hooks/supabase/useCategoryUpsertMutation.ts
+++ b/packages/shared/src/hooks/supabase/useCategoryUpsertMutation.ts
@@ -1,0 +1,19 @@
+import { CategoryTable, MemoSupabaseClient } from '@src/types';
+import { upsertCategories } from '@src/utils';
+import { useMutation } from '@tanstack/react-query';
+
+type MutationVariables = {
+  categoryRequest: CategoryTable['Insert'][];
+};
+type MutationData = Awaited<ReturnType<typeof upsertCategories>>;
+type MutationError = Error;
+
+interface UseCategoryUpsertMutationProps {
+  supabaseClient: MemoSupabaseClient;
+}
+
+export default function useCategoryUpsertMutation({ supabaseClient }: UseCategoryUpsertMutationProps) {
+  return useMutation<MutationData, MutationError, MutationVariables>({
+    mutationFn: ({ categoryRequest }) => upsertCategories(supabaseClient, categoryRequest),
+  });
+}

--- a/packages/shared/src/modules/local-storage/LocalStorage.ts
+++ b/packages/shared/src/modules/local-storage/LocalStorage.ts
@@ -9,4 +9,8 @@ export default class LocalStorage {
   static set(key: LocalStorageKeyType, value: unknown) {
     localStorage.setItem(key, JSON.stringify(value));
   }
+
+  static remove(key: LocalStorageKeyType) {
+    localStorage.removeItem(key);
+  }
 }

--- a/packages/shared/src/utils/Supabase.ts
+++ b/packages/shared/src/utils/Supabase.ts
@@ -33,21 +33,21 @@ export const checkUserLogin = async (supabaseClient: MemoSupabaseClient) => {
 };
 
 export const getCategories = async (supabaseClient: MemoSupabaseClient) =>
-  supabaseClient.from('category').select('*').order('created_at', { ascending: false });
+  supabaseClient.from(SUPABASE.schemaCategory).select('*').order('created_at', { ascending: false });
 
 export const insertCategory = async (supabaseClient: MemoSupabaseClient, categoryRequest: CategoryTable['Insert']) =>
-  supabaseClient.from('category').insert(categoryRequest).select();
+  supabaseClient.from(SUPABASE.schemaCategory).insert(categoryRequest).select();
 
 export const updateCategory = async (
   supabaseClient: MemoSupabaseClient,
   id: CategoryRow['id'],
   categoryRequest: CategoryTable['Update'],
-) => supabaseClient.from('category').update(categoryRequest).eq('id', id).select();
+) => supabaseClient.from(SUPABASE.schemaCategory).update(categoryRequest).eq('id', id).select();
 
 export const deleteCategory = async (supabaseClient: MemoSupabaseClient, id: CategoryRow['id']) =>
-  supabaseClient.from('category').delete().eq('id', id).select();
+  supabaseClient.from(SUPABASE.schemaCategory).delete().eq('id', id).select();
 
 export const upsertCategories = async (
   supabaseClient: MemoSupabaseClient,
   categoryRequest: CategoryTable['Insert'][],
-) => supabaseClient.from('category').upsert(categoryRequest).select();
+) => supabaseClient.from(SUPABASE.schemaCategory).upsert(categoryRequest).select();

--- a/packages/shared/src/utils/Supabase.ts
+++ b/packages/shared/src/utils/Supabase.ts
@@ -1,5 +1,5 @@
 import { SUPABASE } from '@src/constants';
-import { CategoryTable, MemoRow, MemoSupabaseClient, MemoTable } from '@src/types';
+import { CategoryRow, CategoryTable, MemoRow, MemoSupabaseClient, MemoTable } from '@src/types';
 import type { QueryData } from '@supabase/supabase-js';
 
 export const getMemos = async (supabaseClient: MemoSupabaseClient) =>
@@ -37,3 +37,17 @@ export const getCategories = async (supabaseClient: MemoSupabaseClient) =>
 
 export const insertCategory = async (supabaseClient: MemoSupabaseClient, categoryRequest: CategoryTable['Insert']) =>
   supabaseClient.from('category').insert(categoryRequest).select();
+
+export const updateCategory = async (
+  supabaseClient: MemoSupabaseClient,
+  id: CategoryRow['id'],
+  categoryRequest: CategoryTable['Update'],
+) => supabaseClient.from('category').update(categoryRequest).eq('id', id).select();
+
+export const deleteCategory = async (supabaseClient: MemoSupabaseClient, id: CategoryRow['id']) =>
+  supabaseClient.from('category').delete().eq('id', id).select();
+
+export const upsertCategories = async (
+  supabaseClient: MemoSupabaseClient,
+  categoryRequest: CategoryTable['Insert'][],
+) => supabaseClient.from('category').upsert(categoryRequest).select();

--- a/packages/web/src/app/[lng]/memos/components/MemoSidebar/SidebarGroupCategory.tsx
+++ b/packages/web/src/app/[lng]/memos/components/MemoSidebar/SidebarGroupCategory.tsx
@@ -38,7 +38,7 @@ export default memo(function SidebarGroupCategory({ lng }: LanguageType) {
       <SidebarGroupContent>
         <SidebarMenu>
           {categories?.map(category => (
-            <SidebarMenuItem key={category.name}>
+            <SidebarMenuItem key={category.id}>
               <SidebarMenuButton asChild>
                 <button id={category.name} onClick={handleCategoryClick}>
                   <span>{category.name}</span>

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingCategoryForm.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingCategoryForm.tsx
@@ -1,0 +1,128 @@
+import { QUERY_KEY } from '@extension/shared/constants';
+import {
+  useCategoryDeleteMutation,
+  useCategoryPostMutation,
+  useCategoryQuery,
+  useCategoryUpsertMutation,
+} from '@extension/shared/hooks';
+import { Button } from '@src/components/ui/button';
+import { Label } from '@src/components/ui/label';
+import { useSupabaseClient } from '@src/hooks';
+import { useToast } from '@src/hooks/use-toast';
+import { LanguageType } from '@src/modules/i18n';
+import useTranslation from '@src/modules/i18n/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { TrashIcon } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+
+interface CategoryForm {
+  categories: {
+    id: number;
+    name: string;
+  }[];
+}
+
+interface SettingCategoryFormProps extends LanguageType {}
+
+export default function SettingCategoryForm({ lng }: SettingCategoryFormProps) {
+  const { t } = useTranslation(lng);
+
+  const supabaseClient = useSupabaseClient();
+
+  const { categories } = useCategoryQuery({ supabaseClient });
+  const { mutate: deleteCategory } = useCategoryDeleteMutation({ supabaseClient });
+  const { mutate: upsertCategory } = useCategoryUpsertMutation({ supabaseClient });
+  const { mutate: insertCategory } = useCategoryPostMutation({ supabaseClient });
+  const { register, handleSubmit, setValue } = useForm<CategoryForm>({
+    defaultValues: {
+      categories: [],
+    },
+  });
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const handleAddCategory = () => {
+    insertCategory(
+      { name: '' },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
+          toast({
+            title: t('toastTitle.addSuccess'),
+          });
+        },
+      },
+    );
+  };
+
+  const handleCategoryDelete = (id: number) => {
+    deleteCategory(
+      { id },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
+          toast({
+            title: t('toastTitle.deleteSuccess'),
+          });
+        },
+      },
+    );
+  };
+
+  const onCategoryFormSubmit = (data: CategoryForm) => {
+    upsertCategory(
+      { categoryRequest: data.categories },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
+          toast({
+            title: t('toastTitleㅋ.saveSuccess'),
+          });
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (!categories) return;
+
+    setValue(
+      'categories',
+      categories.map(category => ({ id: category.id, name: category.name })),
+    );
+  }, [categories, setValue]);
+
+  return (
+    <form className="grid grid-cols-12" onSubmit={handleSubmit(onCategoryFormSubmit)}>
+      <Label className="col-span-4 grid place-items-center">{t('setting.category')}</Label>
+      <div className="col-span-6 space-y-2">
+        {categories?.map(({ id }, index) => (
+          <div key={id} className="flex items-center gap-2">
+            <input
+              type="text"
+              {...register(`categories.${index}.name`)}
+              className="border-input focus-visible:ring-ring h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-destructive h-9 w-9"
+              type="button"
+              onClick={() => handleCategoryDelete(id)}>
+              <TrashIcon size={16} />
+            </Button>
+          </div>
+        ))}
+        <Button variant="outline" className="w-full" onClick={handleAddCategory} type="button">
+          {t('setting.addCategory')}
+        </Button>
+      </div>
+      <div className="col-span-2 grid place-items-center">
+        <Button type="submit" variant="outline">
+          {t('common.save')}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingCategoryForm.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingCategoryForm.tsx
@@ -43,8 +43,10 @@ export default function SettingCategoryForm({ lng }: SettingCategoryFormProps) {
   const queryClient = useQueryClient();
 
   const handleAddCategory = () => {
+    const defaultCategoryName = t('setting.defaultCategoryName');
+
     insertCategory(
-      { name: '' },
+      { name: defaultCategoryName },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingGuide.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingGuide.tsx
@@ -1,0 +1,29 @@
+import { PATHS } from '@extension/shared/constants';
+import { LocalStorage } from '@extension/shared/modules/local-storage';
+import { Button } from '@src/components/ui/button';
+import { Label } from '@src/components/ui/label';
+import { LanguageType } from '@src/modules/i18n';
+import useTranslation from '@src/modules/i18n/client';
+import { useRouter } from 'next/navigation';
+
+interface SettingGuideProps extends LanguageType {}
+
+export default function SettingGuide({ lng }: SettingGuideProps) {
+  const { t } = useTranslation(lng);
+
+  const router = useRouter();
+
+  const handleRestartGuide = () => {
+    LocalStorage.remove('guide');
+    router.push(PATHS.memos);
+  };
+
+  return (
+    <div className="grid grid-cols-12">
+      <Label className="col-span-4 grid place-items-center">{t('setting.guide')}</Label>
+      <Button variant="outline" className="col-span-2" onClick={handleRestartGuide}>
+        {t('setting.restartGuide')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingLanguage.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingLanguage.tsx
@@ -15,7 +15,7 @@ export default function SettingLanguage({ lng }: SettingLanguageProps) {
       <Label className="col-span-4 grid place-items-center">{t('setting.language')}</Label>
       <Select onValueChange={setLanguageRouter} value={language} aria-label={t('setting.selectLanguage')}>
         <SelectTrigger className="w-[180px]">
-          <SelectValue placeholder="Theme" />
+          <SelectValue />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="ko">한글</SelectItem>

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingLanguage.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/SettingLanguage.tsx
@@ -1,0 +1,27 @@
+import { Label } from '@src/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@src/components/ui/select';
+import { useLanguage } from '@src/hooks';
+import { LanguageType } from '@src/modules/i18n';
+import useTranslation from '@src/modules/i18n/client';
+
+interface SettingLanguageProps extends LanguageType {}
+
+export default function SettingLanguage({ lng }: SettingLanguageProps) {
+  const { t } = useTranslation(lng);
+  const { language, setLanguageRouter } = useLanguage();
+
+  return (
+    <div className="grid grid-cols-12">
+      <Label className="col-span-4 grid place-items-center">{t('setting.language')}</Label>
+      <Select onValueChange={setLanguageRouter} value={language} aria-label={t('setting.selectLanguage')}>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Theme" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="ko">한글</SelectItem>
+          <SelectItem value="en">English</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/index.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/index.tsx
@@ -1,19 +1,98 @@
 'use client';
 
+import { MOTION_VARIANTS, PATHS, QUERY_KEY } from '@extension/shared/constants';
+import {
+  useCategoryDeleteMutation,
+  useCategoryPostMutation,
+  useCategoryQuery,
+  useCategoryUpsertMutation,
+} from '@extension/shared/hooks';
+import { LocalStorage } from '@extension/shared/modules/local-storage';
+import { Button } from '@src/components/ui/button';
 import { Label } from '@src/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@src/components/ui/select';
-import { useLanguage } from '@src/hooks';
+import { useLanguage, useSupabaseClient } from '@src/hooks';
+import { useToast } from '@src/hooks/use-toast';
 import { LanguageType } from '@src/modules/i18n';
 import useTranslation from '@src/modules/i18n/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 interface SettingProps extends LanguageType {}
+
+interface CategoryForm {
+  categories: {
+    id: number;
+    name: string;
+  }[];
+}
 
 export default function Setting({ lng }: SettingProps) {
   const { t } = useTranslation(lng);
   const { language, setLanguageRouter } = useLanguage();
+  const router = useRouter();
+  const supabaseClient = useSupabaseClient();
+  const { categories } = useCategoryQuery({ supabaseClient });
+  const { mutate: deleteCategory } = useCategoryDeleteMutation({ supabaseClient });
+  const { mutate: upsertCategory } = useCategoryUpsertMutation({ supabaseClient });
+  const { mutate: insertCategory } = useCategoryPostMutation({ supabaseClient });
+  const { register, handleSubmit, setValue, watch } = useForm<CategoryForm>({
+    defaultValues: {
+      categories: [],
+    },
+  });
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  console.log(watch('categories'));
+
+  const handleRestartGuide = () => {
+    LocalStorage.remove('guide');
+    router.push(PATHS.memos);
+  };
+
+  const handleAddCategory = () => {
+    insertCategory({ name: '' });
+  };
+
+  const handleCategoryDelete = (id: number) => {
+    deleteCategory({ id });
+  };
+
+  const onCategoryFormSubmit = (data: CategoryForm) => {
+    console.log(data);
+    upsertCategory(
+      { categoryRequest: data.categories },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
+          toast({
+            title: '카테고리 저장 완료',
+          });
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (!categories) return;
+
+    setValue(
+      'categories',
+      categories.map(category => ({ id: category.id, name: category.name })),
+    );
+  }, [categories, setValue]);
 
   return (
-    <section className="grid gap-6">
+    <motion.section
+      className="grid gap-6"
+      variants={MOTION_VARIANTS.fadeInAndOut}
+      initial="initial"
+      animate="animate"
+      exit="exit">
       <div className="grid grid-cols-12">
         <Label className="col-span-4 grid place-items-center">{t('setting.language')}</Label>
         <Select onValueChange={setLanguageRouter} value={language} aria-label={t('setting.selectLanguage')}>
@@ -26,6 +105,55 @@ export default function Setting({ lng }: SettingProps) {
           </SelectContent>
         </Select>
       </div>
-    </section>
+      <div className="grid grid-cols-12">
+        <Label className="col-span-4 grid place-items-center">가이드</Label>
+        <Button variant="outline" className="col-span-2" onClick={handleRestartGuide}>
+          가이드 다시 시작하기
+        </Button>
+      </div>
+      <form className="grid grid-cols-12" onSubmit={handleSubmit(onCategoryFormSubmit)}>
+        <Label className="col-span-4 grid place-items-center">카테고리</Label>
+        <div className="col-span-6 space-y-2">
+          {categories?.map(({ id }, index) => (
+            <div key={id} className="flex items-center gap-2">
+              <input
+                type="text"
+                {...register(`categories.${index}.name`)}
+                className="border-input focus-visible:ring-ring h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive h-9 w-9"
+                onClick={() => handleCategoryDelete(id)}>
+                <span className="sr-only">Delete category</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round">
+                  <path d="M3 6h18" />
+                  <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                  <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                </svg>
+              </Button>
+            </div>
+          ))}
+          <Button variant="outline" className="w-full" onClick={handleAddCategory}>
+            {t('setting.addCategory')}
+          </Button>
+        </div>
+        <div className="col-span-2 grid place-items-center">
+          <Button type="submit" variant="outline">
+            저장
+          </Button>
+        </div>
+      </form>
+    </motion.section>
   );
 }

--- a/packages/web/src/app/[lng]/memos/setting/component/Setting/index.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/component/Setting/index.tsx
@@ -1,109 +1,16 @@
 'use client';
 
-import { MOTION_VARIANTS, PATHS, QUERY_KEY } from '@extension/shared/constants';
-import {
-  useCategoryDeleteMutation,
-  useCategoryPostMutation,
-  useCategoryQuery,
-  useCategoryUpsertMutation,
-} from '@extension/shared/hooks';
-import { LocalStorage } from '@extension/shared/modules/local-storage';
-import { Button } from '@src/components/ui/button';
-import { Label } from '@src/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@src/components/ui/select';
-import { useLanguage, useSupabaseClient } from '@src/hooks';
-import { useToast } from '@src/hooks/use-toast';
+import { MOTION_VARIANTS } from '@extension/shared/constants';
 import { LanguageType } from '@src/modules/i18n';
-import useTranslation from '@src/modules/i18n/client';
-import { useQueryClient } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
-import { TrashIcon } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+
+import SettingCategoryForm from './SettingCategoryForm';
+import SettingGuide from './SettingGuide';
+import SettingLanguage from './SettingLanguage';
 
 interface SettingProps extends LanguageType {}
 
-interface CategoryForm {
-  categories: {
-    id: number;
-    name: string;
-  }[];
-}
-
 export default function Setting({ lng }: SettingProps) {
-  const { t } = useTranslation(lng);
-  const { language, setLanguageRouter } = useLanguage();
-  const router = useRouter();
-  const supabaseClient = useSupabaseClient();
-  const { categories } = useCategoryQuery({ supabaseClient });
-  const { mutate: deleteCategory } = useCategoryDeleteMutation({ supabaseClient });
-  const { mutate: upsertCategory } = useCategoryUpsertMutation({ supabaseClient });
-  const { mutate: insertCategory } = useCategoryPostMutation({ supabaseClient });
-  const { register, handleSubmit, setValue } = useForm<CategoryForm>({
-    defaultValues: {
-      categories: [],
-    },
-  });
-  const { toast } = useToast();
-  const queryClient = useQueryClient();
-
-  const handleRestartGuide = () => {
-    LocalStorage.remove('guide');
-    router.push(PATHS.memos);
-  };
-
-  const handleAddCategory = () => {
-    insertCategory(
-      { name: '' },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
-          toast({
-            title: t('toastTitle.addSuccess'),
-          });
-        },
-      },
-    );
-  };
-
-  const handleCategoryDelete = (id: number) => {
-    deleteCategory(
-      { id },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
-          toast({
-            title: t('toastTitle.deleteSuccess'),
-          });
-        },
-      },
-    );
-  };
-
-  const onCategoryFormSubmit = (data: CategoryForm) => {
-    upsertCategory(
-      { categoryRequest: data.categories },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: QUERY_KEY.category() });
-          toast({
-            title: t('toastTitleㅋ.saveSuccess'),
-          });
-        },
-      },
-    );
-  };
-
-  useEffect(() => {
-    if (!categories) return;
-
-    setValue(
-      'categories',
-      categories.map(category => ({ id: category.id, name: category.name })),
-    );
-  }, [categories, setValue]);
-
   return (
     <motion.section
       className="grid gap-6"
@@ -111,54 +18,9 @@ export default function Setting({ lng }: SettingProps) {
       initial="initial"
       animate="animate"
       exit="exit">
-      <div className="grid grid-cols-12">
-        <Label className="col-span-4 grid place-items-center">{t('setting.language')}</Label>
-        <Select onValueChange={setLanguageRouter} value={language} aria-label={t('setting.selectLanguage')}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="Theme" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="ko">한글</SelectItem>
-            <SelectItem value="en">English</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="grid grid-cols-12">
-        <Label className="col-span-4 grid place-items-center">{t('setting.guide')}</Label>
-        <Button variant="outline" className="col-span-2" onClick={handleRestartGuide}>
-          {t('setting.restartGuide')}
-        </Button>
-      </div>
-      <form className="grid grid-cols-12" onSubmit={handleSubmit(onCategoryFormSubmit)}>
-        <Label className="col-span-4 grid place-items-center">{t('setting.category')}</Label>
-        <div className="col-span-6 space-y-2">
-          {categories?.map(({ id }, index) => (
-            <div key={id} className="flex items-center gap-2">
-              <input
-                type="text"
-                {...register(`categories.${index}.name`)}
-                className="border-input focus-visible:ring-ring h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-destructive h-9 w-9"
-                type="button"
-                onClick={() => handleCategoryDelete(id)}>
-                <TrashIcon size={16} />
-              </Button>
-            </div>
-          ))}
-          <Button variant="outline" className="w-full" onClick={handleAddCategory} type="button">
-            {t('setting.addCategory')}
-          </Button>
-        </div>
-        <div className="col-span-2 grid place-items-center">
-          <Button type="submit" variant="outline">
-            {t('common.save')}
-          </Button>
-        </div>
-      </form>
+      <SettingLanguage lng={lng} />
+      <SettingGuide lng={lng} />
+      <SettingCategoryForm lng={lng} />
     </motion.section>
   );
 }

--- a/packages/web/src/app/[lng]/memos/setting/page.tsx
+++ b/packages/web/src/app/[lng]/memos/setting/page.tsx
@@ -1,12 +1,22 @@
+'use server';
+
+import { QUERY_KEY } from '@extension/shared/constants';
+import { getCategories } from '@extension/shared/utils';
+import { HydrationBoundaryWrapper } from '@src/components';
 import { LanguageParams } from '@src/modules/i18n';
+import { getSupabaseClient } from '@src/modules/supabase/util.server';
 
 import { Setting, SettingHeader } from './component';
 
-export default function Page({ params: { lng } }: LanguageParams) {
+export default async function Page({ params: { lng } }: LanguageParams) {
+  const supabaseClient = getSupabaseClient();
+
   return (
     <main>
       <SettingHeader lng={lng} />
-      <Setting lng={lng} />
+      <HydrationBoundaryWrapper queryKey={QUERY_KEY.category()} queryFn={() => getCategories(supabaseClient)}>
+        <Setting lng={lng} />
+      </HydrationBoundaryWrapper>
     </main>
   );
 }

--- a/packages/web/src/modules/i18n/locales/en/translation.json
+++ b/packages/web/src/modules/i18n/locales/en/translation.json
@@ -79,7 +79,8 @@
     "restartGuide": "Restart guide",
     "category": "Category",
     "addCategory": "Add category",
-    "deleteCategory": "Delete category"
+    "deleteCategory": "Delete category",
+    "defaultCategoryName": "New Category"
   },
   "guide": {
     "next": "Next",

--- a/packages/web/src/modules/i18n/locales/en/translation.json
+++ b/packages/web/src/modules/i18n/locales/en/translation.json
@@ -33,7 +33,10 @@
     "categoryEdited": "The category has been changed successfully!",
     "memoDeleted": "Your memo has been deleted.",
     "memoWishListDeleted": "The memo has been removed from your wish list.",
-    "memoWishListAdded": "The memo has been added to your wish list!"
+    "memoWishListAdded": "The memo has been added to your wish list!",
+    "saveSuccess": "Save completed successfully!",
+    "deleteSuccess": "Delete completed successfully!",
+    "addSuccess": "Add completed successfully!"
   },
   "toastActionMessage": {
     "goTo": "Take me there",
@@ -71,7 +74,12 @@
   },
   "setting": {
     "header": "Settings",
-    "language": "Language"
+    "language": "Language",
+    "guide": "Guide",
+    "restartGuide": "Restart guide",
+    "category": "Category",
+    "addCategory": "Add category",
+    "deleteCategory": "Delete category"
   },
   "guide": {
     "next": "Next",

--- a/packages/web/src/modules/i18n/locales/ko/translation.json
+++ b/packages/web/src/modules/i18n/locales/ko/translation.json
@@ -79,7 +79,8 @@
     "restartGuide": "가이드 다시 시작하기",
     "category": "카테고리",
     "addCategory": "카테고리 추가하기",
-    "deleteCategory": "카테고리 삭제하기"
+    "deleteCategory": "카테고리 삭제하기",
+    "defaultCategoryName": "새로운 카테고리"
   },
   "guide": {
     "next": "다음",

--- a/packages/web/src/modules/i18n/locales/ko/translation.json
+++ b/packages/web/src/modules/i18n/locales/ko/translation.json
@@ -15,7 +15,8 @@
     "time": "시간",
     "event": "이벤트",
     "more": "더보기",
-    "title": "제목"
+    "title": "제목",
+    "save": "저장"
   },
   "sideBar": {
     "memo": "나의 메모",
@@ -31,7 +32,10 @@
     "categoryEdited": "카테고리가 성공적으로 변경되었어요!",
     "memoDeleted": "메모가 삭제되었어요.",
     "memoWishListDeleted": "위시리스트에서 메모를 제거했어요.",
-    "memoWishListAdded": "위시리스트에 메모를 추가했어요!"
+    "memoWishListAdded": "위시리스트에 메모를 추가했어요!",
+    "saveSuccess": "저장이 완료되었어요!",
+    "deleteSuccess": "삭제가 완료되었어요!",
+    "addSuccess": "추가가 완료되었어요!"
   },
   "toastActionMessage": {
     "goTo": "바로 이동하기",
@@ -54,8 +58,7 @@
     "description": "메모 기능을 사용하시려면 확장 프로그램이 필요합니다. 지금 설치하러 가볼까요?",
     "cancel": "다음에 설치할게요",
     "ok": "네, 설치하러 갈게요",
-    "close": "닫기",
-    "save": "저장"
+    "close": "닫기"
   },
   "dialogVersion": {
     "title": "새로운 버전이 나왔어요!",
@@ -71,7 +74,12 @@
   },
   "setting": {
     "header": "환경설정",
-    "language": "언어 설정"
+    "language": "언어 설정",
+    "guide": "가이드",
+    "restartGuide": "가이드 다시 시작하기",
+    "category": "카테고리",
+    "addCategory": "카테고리 추가하기",
+    "deleteCategory": "카테고리 삭제하기"
   },
   "guide": {
     "next": "다음",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **새로운 기능**
  - 카테고리 삭제, 수정, 추가를 위한 새로운 훅(`useCategoryDeleteMutation`, `useCategoryPatchMutation`, `useCategoryUpsertMutation`)이 추가되었습니다.
  - 설정 인터페이스에 카테고리를 관리하는 새로운 컴포넌트(`SettingCategoryForm`)가 추가되었습니다.
  - 언어 선택을 위한 새로운 컴포넌트(`SettingLanguage`)가 도입되었습니다.
  - 가이드를 재시작하는 버튼을 포함한 새로운 컴포넌트(`SettingGuide`)가 추가되었습니다.
  - 카테고리 관리 기능을 향상시키기 위해 여러 비동기 함수가 추가되었습니다.

- **버그 수정**
  - 카테고리 쿼리 기능이 개선되어 React의 Suspense를 지원하게 되었습니다.

- **문서화**
  - 다양한 성공 메시지와 설정 옵션이 추가되어 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->