### PR TITLE
Fix: updated_at 불일치 이슈 해결

### DIFF
--- a/packages/shared/src/hooks/supabase/useMemoPatchMutation.ts
+++ b/packages/shared/src/hooks/supabase/useMemoPatchMutation.ts
@@ -35,7 +35,10 @@ export default function useMemoPatchMutation() {
 
       if (currentMemoIndex === -1 || !currentMemoBase) throw new NoMemoError();
 
-      updatedMemosData.splice(currentMemoIndex, 1, { ...currentMemoBase, ...request });
+      updatedMemosData.splice(currentMemoIndex, 1, {
+        ...{ ...currentMemoBase, updated_at: new Date().toISOString() },
+        ...request,
+      });
 
       await queryClient.setQueryData(QUERY_KEY.memos(), { ...previousMemos, data: updatedMemosData });
 

--- a/packages/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/packages/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useMemoPatchMutation, useMemoQuery } from '@extension/shared/hooks';
 import { useSearchParams } from '@extension/shared/modules/search-params';
-import { formatDate } from '@extension/shared/utils';
 import { Button } from '@extension/ui';
 import { Card, CardContent, Dialog, DialogContent, Textarea } from '@src/components/ui';
 import { LanguageType } from '@src/modules/i18n';
@@ -9,19 +8,17 @@ import useTranslation from '@src/modules/i18n/client';
 import { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
+import { useRouter } from 'next/navigation';
 import { MemoInput } from '../../_types';
 import MemoCardFooter from '../MemoCardFooter';
 import MemoCardHeader from '../MemoCardHeader';
 import UnsavedChangesAlert from './UnsavedChangesAlert';
-import { useRouter } from 'next/navigation';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
 
 import relativeTime from 'dayjs/plugin/relativeTime';
 
-import 'dayjs/locale/ko';
-import 'dayjs/locale/en';
 import dayjs from 'dayjs';
+import 'dayjs/locale/en';
+import 'dayjs/locale/ko';
 
 interface MemoDialog extends LanguageType {}
 

--- a/packages/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/packages/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -13,8 +13,15 @@ import { MemoInput } from '../../_types';
 import MemoCardFooter from '../MemoCardFooter';
 import MemoCardHeader from '../MemoCardHeader';
 import UnsavedChangesAlert from './UnsavedChangesAlert';
-import { usePropagateEvent } from '@src/hooks';
 import { useRouter } from 'next/navigation';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+import 'dayjs/locale/ko';
+import 'dayjs/locale/en';
+import dayjs from 'dayjs';
 
 interface MemoDialog extends LanguageType {}
 
@@ -26,8 +33,10 @@ export default function MemoDialog({ lng }: MemoDialog) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { mutate: mutateMemoPatch } = useMemoPatchMutation();
   const [showAlert, setShowAlert] = useState(false);
-  const [open, setOpen] = useState(!!id);
   const router = useRouter();
+
+  dayjs.extend(relativeTime);
+  dayjs.locale(lng === 'ko' ? 'ko' : 'en');
 
   const { register, watch, setValue, control } = useForm<MemoInput>({
     defaultValues: {
@@ -105,7 +114,7 @@ export default function MemoDialog({ lng }: MemoDialog) {
 
               <div className="h-4" />
               <span className="text-muted-foreground float-right text-xs">
-                {t('common.updatedAt')} {formatDate(memoData.updated_at, 'yyyy.mm.dd')}
+                {t('common.lastUpdated', { time: dayjs(memoData.updated_at).fromNow(true) })}
               </span>
             </CardContent>
 

--- a/packages/web/src/modules/i18n/locales/en/translation.json
+++ b/packages/web/src/modules/i18n/locales/en/translation.json
@@ -20,7 +20,8 @@
     "title": "Title",
     "tomorrow": "Tomorrow",
     "yesterday": "Yesterday",
-    "workWeek": "Work Week"
+    "workWeek": "Work Week",
+    "lastUpdated": "Last updated {{time}} ago"
   },
 
   "sideBar": {

--- a/packages/web/src/modules/i18n/locales/ko/translation.json
+++ b/packages/web/src/modules/i18n/locales/ko/translation.json
@@ -20,7 +20,8 @@
     "tomorrow": "내일",
     "yesterday": "어제",
     "workWeek": "주간",
-    "close": "닫기"
+    "close": "닫기",
+    "lastUpdated": "{{time}} 전 업데이트"
   },
 
   "sideBar": {
@@ -113,7 +114,8 @@
     "deleteSuccess": "삭제가 완료되었어요!",
     "addSuccess": "추가가 완료되었어요!",
     "errorSave": "저장에 실패했어요!",
-    "successSave": "변경사항이 저장되었습니다."
+    "successSave": "변경사항이 저장되었습니다.",
+    "memo_updated_at": "{{time}}에 수정됨"
   },
   "toastActionMessage": {
     "goTo": "바로 이동하기",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 메모의 마지막 업데이트 시간을 상대적인 시간 형식으로 표시하도록 개선
	- 다국어 지원을 위해 영어와 한국어 번역에 마지막 업데이트 관련 문구 추가

- **버그 수정**
	- 메모 업데이트 시 `updated_at` 타임스탬프가 일관되게 갱신되도록 수정

- **스타일**
	- 메모 대화 상자의 시간 표시 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->