### PR TITLE
캐싱된 supabaseClient 를 사용하도록 수정합니다.

### DIFF
--- a/packages/web/src/modules/supabase/util.server.ts
+++ b/packages/web/src/modules/supabase/util.server.ts
@@ -14,7 +14,7 @@ export const getSupabaseClient = () => {
 
 	const cookieStore = cookies();
 
-	return createServerClient<Database, "memo", Database["memo"]>(
+	supabaseClient = createServerClient<Database, "memo", Database["memo"]>(
 		CONFIG.supabaseUrl,
 		CONFIG.supabaseAnonKey,
 		{
@@ -31,6 +31,8 @@ export const getSupabaseClient = () => {
 			db: { schema: SUPABASE.table.memo },
 		},
 	);
+
+	return supabaseClient;
 };
 
 export const signInWithOAuth = async (provider: Provider) => {


### PR DESCRIPTION
- 현재 코드 구조는 `supabaseClient`를 전역으로 선언하되 할당을 하고 있지 않아 `if`문을 타고 있지 않습니다. 이는 아마 원하셨던 바는 아니었던 것 같습니다.
- `supabaseClient`가 nullish 한 경우 `createServerClient`로 생성된 객체 값을 할당하고, 이를 반환합니다.
- 이후에는 `supabaseClient` 가 정상적으로 할당되어 반환됩니다

> 다만 말씀드렸던 vercel serverless function 의 cold start 특성상 이 캐싱의 이점은 제한적일 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * Supabase 클라이언트의 재사용으로 서버 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->