### PR TITLE
fix(dialog): 드롭다운 메뉴 외부 클릭 시 다이얼로그가 닫히는 버그 수정

### DIFF
--- a/e2e/tests/mocked/memo-dialog-dropdown.test.ts
+++ b/e2e/tests/mocked/memo-dialog-dropdown.test.ts
@@ -1,0 +1,111 @@
+import { PATHS } from "@web-memo/shared/constants";
+import { expect, test } from "../fixtures";
+import { gotoSafely, LANGUAGE, login, skipGuide } from "../lib";
+import {
+	createMockCategory,
+	createMockMemo,
+	MockSupabaseStore,
+	resetMockIds,
+	setupSupabaseMocks,
+} from "../lib/mocks";
+
+test.describe("MemoDialog 드롭다운 클릭 시 다이얼로그 닫힘 버그 수정", () => {
+	let store: MockSupabaseStore;
+	let memoText: string;
+
+	test.beforeEach(async ({ page }) => {
+		resetMockIds();
+		store = new MockSupabaseStore();
+
+		memoText = `Test Memo ${Date.now()}`;
+		const category = createMockCategory({ name: "Test Category" });
+		store.addCategory(category);
+
+		const mockMemo = createMockMemo({
+			memo: memoText,
+			title: memoText,
+			category_id: category.id,
+		});
+		store.addMemo(mockMemo);
+
+		await setupSupabaseMocks(page, store);
+
+		await login(page);
+		await skipGuide(page);
+		await gotoSafely({
+			page,
+			url: `${LANGUAGE}${PATHS.memos}`,
+			regexp: new RegExp(PATHS.memos),
+		});
+	});
+
+	test("드롭다운 메뉴 외부 클릭 시 다이얼로그가 닫히지 않아야 한다", async ({
+		page,
+	}) => {
+		const memoItem = page.locator(".memo-item", {
+			hasText: memoText,
+		});
+
+		await memoItem.click();
+
+		await expect(page.getByTestId("memo-textarea")).toBeVisible();
+
+		await page.getByTestId("memo-option").click();
+
+		const dropdownContent = page.locator('[role="menu"]');
+		await expect(dropdownContent).toBeVisible();
+
+		const dialogOverlay = page.locator('[data-state="open"].fixed.inset-0');
+		await dialogOverlay.click({ position: { x: 10, y: 10 } });
+
+		await expect(dropdownContent).not.toBeVisible();
+
+		await expect(page.getByTestId("memo-textarea")).toBeVisible();
+	});
+
+	test("드롭다운 서브메뉴(카테고리 변경) 외부 클릭 시 다이얼로그가 닫히지 않아야 한다", async ({
+		page,
+	}) => {
+		const memoItem = page.locator(".memo-item", {
+			hasText: memoText,
+		});
+
+		await memoItem.click();
+
+		await expect(page.getByTestId("memo-textarea")).toBeVisible();
+
+		await page.getByTestId("memo-option").click();
+
+		const dropdownContent = page.locator('[role="menu"]');
+		await expect(dropdownContent).toBeVisible();
+
+		const categorySubmenu = page.getByRole("menuitem", {
+			name: /category|카테고리/i,
+		});
+		await categorySubmenu.hover();
+
+		await page.waitForTimeout(300);
+
+		const dialogOverlay = page.locator('[data-state="open"].fixed.inset-0');
+		await dialogOverlay.click({ position: { x: 10, y: 10 } });
+
+		await expect(page.getByTestId("memo-textarea")).toBeVisible();
+	});
+
+	test("다이얼로그 overlay 직접 클릭 시에는 다이얼로그가 닫혀야 한다", async ({
+		page,
+	}) => {
+		const memoItem = page.locator(".memo-item", {
+			hasText: memoText,
+		});
+
+		await memoItem.click();
+
+		await expect(page.getByTestId("memo-textarea")).toBeVisible();
+
+		const dialogOverlay = page.locator('[data-state="open"].fixed.inset-0');
+		await dialogOverlay.click({ position: { x: 10, y: 10 }, force: true });
+
+		await expect(page.getByTestId("memo-textarea")).not.toBeVisible();
+	});
+});

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -41,9 +41,15 @@ const DialogContent = React.forwardRef<
 >(({ className, children, onClose, ...props }, ref) => {
 	useKeyboardBind({ key: "Escape", callback: onClose ?? (() => {}) });
 
+	const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+		if (event.target === event.currentTarget) {
+			onClose?.();
+		}
+	};
+
 	return (
 		<DialogPortal>
-			<DialogOverlay onClick={onClose} />
+			<DialogOverlay onClick={handleOverlayClick} />
 			<DialogPrimitive.Content
 				ref={ref}
 				className={cn(


### PR DESCRIPTION
## Summary
- MemoDialog에서 카테고리 드롭다운을 열고 외부를 클릭하면 웹사이트가 멈추는 문제 해결
- DialogOverlay의 onClick 핸들러에서 이벤트 버블링 방지 로직 추가
- `event.target === event.currentTarget` 조건으로 overlay 직접 클릭만 처리

## Root Cause
DropdownMenu가 열린 상태에서 바깥을 클릭하면:
1. DropdownMenu를 닫기 위한 클릭 이벤트 발생
2. 이벤트가 버블링되어 DialogOverlay의 onClick 핸들러까지 도달
3. onClose() → closeDialog() 호출
4. history.back() 또는 searchParams 조작과 DropdownMenu 닫힘 로직이 충돌
5. 웹사이트 멈춤

## Changes
- `packages/ui/src/components/dialog.tsx`: handleOverlayClick 함수 추가
- `e2e/tests/mocked/memo-dialog-dropdown.test.ts`: E2E 테스트 추가
- `e2e/tests/lib/mocks/supabaseRoutes.ts`: 카테고리 API mock 추가

## Test plan
- [ ] 메모 다이얼로그 열기
- [ ] 옵션 드롭다운 메뉴 열기
- [ ] 드롭다운 외부 클릭 시 다이얼로그가 닫히지 않는지 확인
- [ ] 카테고리 변경 서브메뉴 열기
- [ ] 서브메뉴 외부 클릭 시 다이얼로그가 닫히지 않는지 확인
- [ ] 드롭다운이 닫힌 상태에서 overlay 클릭 시 다이얼로그가 정상적으로 닫히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)