### PR TITLE
fix: Expo Go 환경에서 OAuth 소셜 로그인 리다이렉트 수정

### DIFF
--- a/apps/app/lib/auth/useOAuth.ts
+++ b/apps/app/lib/auth/useOAuth.ts
@@ -1,11 +1,15 @@
 import { supabase } from "@/lib/supabase/client";
-import * as Linking from "expo-linking";
+import { makeRedirectUri } from "expo-auth-session";
 import * as QueryParams from "expo-auth-session/build/QueryParams";
 import * as WebBrowser from "expo-web-browser";
 
+
 WebBrowser.maybeCompleteAuthSession();
 
-const redirectTo = Linking.createURL("/");
+const redirectTo = makeRedirectUri({
+  scheme: "webmemo",
+  path: "/",
+});
 
 console.log("📱 OAuth Redirect URI:", redirectTo);
 


### PR DESCRIPTION
## Summary
- Expo Go에서 소셜 로그인(Google/Kakao) 시 앱으로 돌아오지 않고 localhost로 리다이렉트되는 문제 수정
- `expo-linking`의 `Linking.createURL("/")` → `expo-auth-session`의 `makeRedirectUri({ scheme: "webmemo", path: "/" })`로 변경
- `makeRedirectUri`는 환경별로 올바른 redirect URI를 자동 생성 (Expo Go / Dev Build / Web)

## Root Cause
Expo Go에서 `Linking.createURL("/")`은 `exp://192.168.x.x:8081/`을 반환하는데, 이 URL이 Supabase Dashboard의 허용된 Redirect URL에 없어 localhost로 폴백됨.

## Manual Step Required
Supabase Dashboard > Authentication > URL Configuration > Redirect URLs에 `exp://*` 패턴 또는 개발 IP 등록 필요.

## Test plan
- [ ] `console.log`로 redirectTo 값 확인 (`exp://...` 형태)
- [ ] Expo Go에서 Google 소셜 로그인 성공 확인
- [ ] Expo Go에서 Kakao 소셜 로그인 성공 확인
- [ ] Development build에서 `webmemo:///` 출력 및 로그인 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)