### PR TITLE
feat: 인앱 리뷰 요청 배너 추가

### DIFF
--- a/apps/chrome-extension/lib/background/index.ts
+++ b/apps/chrome-extension/lib/background/index.ts
@@ -16,6 +16,8 @@ chrome.runtime.onInstalled.addListener(async () => {
 	const language = await ChromeSyncStorage.get(STORAGE_KEYS.language);
 	const uiLanguage = I18n.getUILanguage();
 	if (!language) ChromeSyncStorage.set(STORAGE_KEYS.language, uiLanguage);
+	const installDate = await ChromeSyncStorage.get(STORAGE_KEYS.installDate);
+	if (!installDate) ChromeSyncStorage.set(STORAGE_KEYS.installDate, Date.now());
 });
 
 // 확장 프로그램이 설치되었을 때 contextMenus를 설정한다.

--- a/packages/shared/src/modules/chrome-storage/constant.ts
+++ b/packages/shared/src/modules/chrome-storage/constant.ts
@@ -7,4 +7,6 @@ export const STORAGE_KEYS = {
 	tabHeight: "tabHeight",
 	chatMessages: "chatMessages",
 	textSelectionEnabled: "textSelectionEnabled",
+	installDate: "installDate",
+	reviewDismissed: "reviewDismissed",
 } as const;

--- a/pages/side-panel/src/components/ReviewRequestBanner.tsx
+++ b/pages/side-panel/src/components/ReviewRequestBanner.tsx
@@ -1,0 +1,64 @@
+import { Button, ErrorBoundary } from "@web-memo/ui";
+import { StarIcon, XIcon } from "lucide-react";
+import { Suspense } from "react";
+import { useReviewRequest } from "@src/hooks";
+
+const REVIEW_URL =
+	"https://chromewebstore.google.com/detail/web-memo/eaiojpmgklfngpjddhoalgcpkepgkclh/reviews";
+
+export default function ReviewRequestBanner() {
+	return (
+		<ErrorBoundary FallbackComponent={() => null}>
+			<Suspense fallback={null}>
+				<ReviewRequestBannerContent />
+			</Suspense>
+		</ErrorBoundary>
+	);
+}
+
+function ReviewRequestBannerContent() {
+	const { shouldShow, dismiss } = useReviewRequest();
+
+	if (!shouldShow) return null;
+
+	return (
+		<div className="shrink-0 my-2 rounded-lg border bg-muted/50 p-3">
+			<div className="flex items-start gap-2">
+				<StarIcon className="size-4 shrink-0 text-yellow-500 mt-0.5" />
+				<div className="flex-1 min-w-0">
+					<p className="text-xs text-foreground">
+						Web Memo가 도움이 되셨나요? 리뷰를 남겨주세요!
+					</p>
+					<div className="flex gap-2 mt-2">
+						<Button
+							size="sm"
+							variant="default"
+							className="h-7 text-xs"
+							onClick={() => {
+								window.open(REVIEW_URL, "_blank");
+								dismiss();
+							}}
+						>
+							리뷰 남기기
+						</Button>
+						<Button
+							size="sm"
+							variant="ghost"
+							className="h-7 text-xs text-muted-foreground"
+							onClick={dismiss}
+						>
+							다시 보지 않기
+						</Button>
+					</div>
+				</div>
+				<button
+					type="button"
+					onClick={dismiss}
+					className="shrink-0 text-muted-foreground hover:text-foreground"
+				>
+					<XIcon className="size-3.5" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/pages/side-panel/src/components/SidePanelContent.tsx
+++ b/pages/side-panel/src/components/SidePanelContent.tsx
@@ -1,4 +1,4 @@
-import { Header, MemoSection, ResizeHandle, TabSection } from "@src/components";
+import { Header, MemoSection, ResizeHandle, ReviewRequestBanner, TabSection } from "@src/components";
 import { useResizablePanel } from "@src/hooks";
 import { useDidMount, useTabQuery } from "@web-memo/shared/hooks";
 import { bridge } from "@web-memo/shared/modules/extension-bridge";
@@ -23,6 +23,7 @@ export default function SidePanelContent() {
 			className="bg-background text-foreground relative flex h-lvh flex-col px-4 max-w-none overflow-x-hidden"
 		>
 			<Header />
+			<ReviewRequestBanner />
 			<TabSection tabHeight={tabHeight} />
 			<ResizeHandle
 				tabHeight={tabHeight}

--- a/pages/side-panel/src/components/index.ts
+++ b/pages/side-panel/src/components/index.ts
@@ -4,5 +4,6 @@ export { default as LoginSection } from "./LoginSection";
 export { default as MemoSection } from "./MemoSection";
 export { default as QueryProvider } from "./QueryProvider";
 export { default as ResizeHandle } from "./ResizeHandle";
+export { default as ReviewRequestBanner } from "./ReviewRequestBanner";
 export { default as TabSection } from "./TabSection";
 export { default as Chat } from "./TabSection/components/Chat";

--- a/pages/side-panel/src/hooks/index.ts
+++ b/pages/side-panel/src/hooks/index.ts
@@ -2,3 +2,4 @@ export type { ChatMessage } from "./useChat";
 export { default as useChat } from "./useChat";
 export { default as useResizablePanel } from "./useResizablePanel";
 export { default as useSummary } from "./useSummary";
+export { default as useReviewRequest } from "./useReviewRequest";

--- a/pages/side-panel/src/hooks/useReviewRequest.ts
+++ b/pages/side-panel/src/hooks/useReviewRequest.ts
@@ -1,0 +1,50 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	ChromeSyncStorage,
+	STORAGE_KEYS,
+} from "@web-memo/shared/modules/chrome-storage";
+import { MemoService } from "@web-memo/shared/utils";
+import { useCallback, useState } from "react";
+import { useSupabaseClientQuery } from "@web-memo/shared/hooks";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const REQUIRED_MEMO_COUNT = 10;
+
+export default function useReviewRequest() {
+	const [dismissed, setDismissed] = useState(false);
+	const { data: supabaseClient } = useSupabaseClientQuery();
+
+	const { data: shouldShow = false } = useQuery({
+		queryKey: ["reviewRequest"],
+		queryFn: async () => {
+			const reviewDismissed = await ChromeSyncStorage.get<boolean>(
+				STORAGE_KEYS.reviewDismissed,
+			);
+			if (reviewDismissed) return false;
+
+			const installDate = await ChromeSyncStorage.get<number>(
+				STORAGE_KEYS.installDate,
+			);
+			if (!installDate) return false;
+			if (Date.now() - installDate < SEVEN_DAYS_MS) return false;
+
+			const memoService = new MemoService(supabaseClient);
+			const result = await memoService.getMemosPaginated({ limit: 1 });
+			const count = result.count ?? 0;
+			if (count < REQUIRED_MEMO_COUNT) return false;
+
+			return true;
+		},
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+
+	const dismiss = useCallback(async () => {
+		setDismissed(true);
+		await ChromeSyncStorage.set(STORAGE_KEYS.reviewDismissed, true);
+	}, []);
+
+	return {
+		shouldShow: shouldShow && !dismissed,
+		dismiss,
+	};
+}


### PR DESCRIPTION
## 요약
- Chrome Web Store 검색 순위 향상을 위해 사이드 패널에 리뷰 요청 배너 추가
- 조건 충족 시(메모 10개 이상 + 설치 7일 경과) 배너 표시
- "다시 보지 않기" 옵션으로 영구 해제 가능

## 변경사항
- `packages/shared/src/modules/chrome-storage/constant.ts`: `installDate`, `reviewDismissed` 스토리지 키 추가
- `apps/chrome-extension/lib/background/index.ts`: 확장 프로그램 설치 시 설치 날짜 기록
- `pages/side-panel/src/hooks/useReviewRequest.ts`: 리뷰 요청 표시 조건 판단 훅 (새 파일)
- `pages/side-panel/src/components/ReviewRequestBanner.tsx`: 리뷰 요청 배너 UI 컴포넌트 (새 파일)
- `pages/side-panel/src/components/SidePanelContent.tsx`: Header 아래에 배너 삽입

## 표시 조건
1. `reviewDismissed`가 `true`가 아닐 것
2. 설치 후 7일 이상 경과
3. 메모 10개 이상 작성

## 테스트 계획
- [ ] `pnpm type-check` 통과 확인
- [ ] `pnpm lint` 통과 확인
- [ ] `pnpm build:extension` 빌드 성공 확인
- [ ] 조건 미충족 시 배너 미표시 확인
- [ ] 조건 충족 시 배너 표시 확인
- [ ] "리뷰 남기기" 클릭 시 Chrome Web Store 리뷰 페이지 열림 확인
- [ ] "다시 보지 않기" 클릭 시 배너 영구 해제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)