### PR TITLE
chore: Vercel 설정을 vercel.json으로 코드 관리

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/api/transcript", "destination": "/api/transcript.py" }
+  ]
+}


### PR DESCRIPTION
## 요약
- Vercel 배포 설정을 대시보드 대신 `vercel.json`으로 관리하여 IaC 적용

## 변경사항
- `vercel.json` 신규 생성
  - `/api/transcript` → `/api/transcript.py` rewrite 규칙 포함

## 참고
- `vercel.json`은 대시보드 설정보다 우선 적용됨
- 배포 후 정상 확인되면 대시보드의 중복 rewrite 규칙 제거 필요

## 테스트 계획
- [ ] Vercel 배포 후 `/api/transcript` rewrite 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)