### PR TITLE
fix: CI 캐시 키에서 next.config 파일명 불일치 수정

### DIFF
--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: |
             apps/web/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', 'apps/web/next.config.js') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', 'apps/web/next.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           path: |
             apps/web/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', 'apps/web/next.config.js') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', 'apps/web/next.config.mjs') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
 


### PR DESCRIPTION
## 요약
- CI 워크플로우의 Next.js 캐시 키가 존재하지 않는 `next.config.js`를 참조하던 버그 수정

## 변경사항
- `.github/workflows/cd-web.yml`: `next.config.js` → `next.config.mjs`
- `.github/workflows/e2e.yml`: `next.config.js` → `next.config.mjs`

## 상세
실제 파일명은 `next.config.mjs`이나 캐시 키에서 `next.config.js`를 해싱하고 있어
설정 파일 변경 시 캐시가 무효화되지 않는 문제가 있었음

## 테스트 계획
- [ ] CI `cd-web` job 정상 빌드 확인
- [ ] E2E 워크플로우 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)