### PR TITLE
fix: Turbo 캐시 output 경로 수정으로 익스텐션 업로드 에러 해결

### DIFF
--- a/apps/chrome-extension/turbo.json
+++ b/apps/chrome-extension/turbo.json
@@ -1,1 +1,9 @@
-{ "extends": ["//"], "tags": ["app"] }
+{
+	"extends": ["//"],
+	"tags": ["app"],
+	"tasks": {
+		"build": {
+			"outputs": ["../../dist/**", "!../../dist/side-panel/**", "!../../dist/options/**", "!../../dist/content-ui/**"]
+		}
+	}
+}

--- a/pages/content-ui/turbo.json
+++ b/pages/content-ui/turbo.json
@@ -1,1 +1,9 @@
-{ "extends": ["//"], "tags": ["app"] }
+{
+	"extends": ["//"],
+	"tags": ["app"],
+	"tasks": {
+		"build": {
+			"outputs": ["../../dist/content-ui/**"]
+		}
+	}
+}

--- a/pages/options/turbo.json
+++ b/pages/options/turbo.json
@@ -1,1 +1,9 @@
-{ "extends": ["//"], "tags": ["app"] }
+{
+	"extends": ["//"],
+	"tags": ["app"],
+	"tasks": {
+		"build": {
+			"outputs": ["../../dist/options/**"]
+		}
+	}
+}

--- a/pages/side-panel/turbo.json
+++ b/pages/side-panel/turbo.json
@@ -1,1 +1,9 @@
-{ "extends": ["//"], "tags": ["app"] }
+{
+	"extends": ["//"],
+	"tags": ["app"],
+	"tasks": {
+		"build": {
+			"outputs": ["../../dist/side-panel/**"]
+		}
+	}
+}


### PR DESCRIPTION
## 요약
- Turbo 캐시의 build output 경로가 실제 Vite 빌드 출력 경로와 불일치하여 Chrome Web Store 업로드 시 `PKG_INVALID_ZIP` 에러가 발생하는 문제를 수정합니다.

## 변경사항
- `apps/chrome-extension/turbo.json`: 루트 `dist/**` 경로를 build output으로 지정 (하위 페이지 디렉토리 제외)
- `pages/side-panel/turbo.json`: `../../dist/side-panel/**` 경로를 build output으로 지정
- `pages/options/turbo.json`: `../../dist/options/**` 경로를 build output으로 지정
- `pages/content-ui/turbo.json`: `../../dist/content-ui/**` 경로를 build output으로 지정

## 원인 분석
- Vite 빌드는 모두 루트 `dist/`에 출력하지만, Turbo의 `outputs: ["dist/**"]`는 패키지 로컬 디렉토리 기준으로 해석됨
- 모든 빌드가 Turbo 캐시 히트되면 루트 `dist/`가 비어있는 상태로 남아 zip이 0바이트로 생성됨
- 관련 에러: https://github.com/guesung/Web-Memo/actions/runs/22441800142/job/64986009826

## 테스트 계획
- [ ] `pnpm build:extension && pnpm zip` 후 `dist-zip/extension.zip`에 `manifest.json` 포함 확인
- [ ] CI에서 캐시 히트 상태에서도 정상적으로 zip 생성 및 업로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)