### PR TITLE
fix: 메모 중복 저장 버그 수정

### DIFF
--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
@@ -9,7 +9,7 @@ import {
 } from "@web-memo/shared/hooks";
 import { bridge } from "@web-memo/shared/modules/extension-bridge";
 import { getTabInfo } from "@web-memo/shared/utils/extension";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 interface SaveMemoOptions extends Partial<MemoInput> {
@@ -31,6 +31,7 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 	const { mutate: upsertMemo } = useMemoUpsertMutation();
 	const { mutate: patchMemo } = useMemoPatchMutation();
 	const [isSaving, setIsSaving] = useState(false);
+	const pendingDataRef = useRef<SaveMemoOptions | null>(null);
 
 	useDidMount(() => {
 		bridge.handle.REFETCH_THE_MEMO_LIST_FROM_WEB(refetchMemo);
@@ -48,6 +49,11 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 
 	const saveMemo = useCallback(
 		async (overrides?: SaveMemoOptions) => {
+			if (isSaving) {
+				pendingDataRef.current = overrides ?? null;
+				return;
+			}
+
 			const currentValues = getValues();
 			const memoInput: MemoInput = {
 				memo: overrides?.memo ?? currentValues.memo,
@@ -56,6 +62,7 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 			};
 
 			setIsSaving(true);
+			pendingDataRef.current = null;
 
 			const tabInfo = overrides?.tabInfo ?? (await getTabInfo());
 			const memoId = overrides?.memoId ?? memoData?.id;
@@ -75,16 +82,22 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 					onSuccess: () => {
 						setTimeout(() => {
 							setIsSaving(false);
+							if (pendingDataRef.current !== null) {
+								const pendingData = pendingDataRef.current;
+								pendingDataRef.current = null;
+								saveMemo(pendingData);
+							}
 						}, 500);
 						onSaveSuccess?.(memoInput);
 					},
 					onError: () => {
 						setIsSaving(false);
+						pendingDataRef.current = null;
 					},
 				},
 			);
 		},
-		[getValues, memoData?.id, upsertMemo, onSaveSuccess],
+		[isSaving, getValues, memoData?.id, upsertMemo, onSaveSuccess],
 	);
 
 	const handleMemoChange = useCallback(


### PR DESCRIPTION
## 요약
메모 저장 시 race condition으로 인한 중복 메모 생성 버그를 수정했습니다.

## 문제 원인
- `saveMemo` 함수에서 `isSaving` 상태가 존재하지만 저장 시작 전에 체크하지 않음
- 빠른 타이핑 시 debounce 후 여러 `saveMemo` 호출이 동시에 발생
- 두 개의 `getMemoByUrl()` 호출이 모두 null을 반환 (첫 번째 insert 완료 전)
- 결과적으로 두 개의 `insertMemo()` 실행 → 중복 메모 생성

## 변경사항
- `saveMemo` 시작 시 `isSaving` 체크 추가 - 이미 저장 중이면 early return
- `pendingDataRef` 추가 - 저장 중 대기할 데이터를 ref로 관리
- `onSuccess`에서 대기 중인 데이터 처리 - 저장 완료 후 큐에 있는 데이터로 재저장
- `onError`에서 `pendingDataRef` 초기화 - 에러 시 대기 중인 데이터 클리어

## 테스트 계획
- [ ] 새 페이지에서 빠르게 타이핑 → 중복 메모 생성 안됨 확인
- [ ] 타이핑 중 하트(isWish) 버튼 클릭 → 정상 동작 확인
- [ ] 카테고리 빠르게 변경 → 정상 동작 확인
- [ ] Supabase 대시보드에서 중복 메모 없음 확인

🤖 Generated with [Claude Code](https://claude.ai/code)