### PR TITLE
fix: 사이드 패널 메모 작성 중 커서가 끝으로 이동하는 버그 수정

### DIFF
--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
@@ -9,7 +9,7 @@ import {
 } from "@web-memo/shared/hooks";
 import { bridge } from "@web-memo/shared/modules/extension-bridge";
 import { getTabInfo } from "@web-memo/shared/utils/extension";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 interface SaveMemoOptions extends Partial<MemoInput> {
@@ -31,6 +31,7 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 	const { mutate: upsertMemo } = useMemoUpsertMutation();
 	const { mutate: patchMemo } = useMemoPatchMutation();
 	const [isSaving, setIsSaving] = useState(false);
+	const initializedMemoIdRef = useRef<number | null>(null);
 
 	useDidMount(() => {
 		bridge.handle.REFETCH_THE_MEMO_LIST_FROM_WEB(refetchMemo);
@@ -39,11 +40,18 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 
 	useEffect(
 		function initMemoData() {
-			setValue("memo", memoData?.memo ?? "");
+			const currentMemoId = memoData?.id ?? null;
+			const isNewMemo = initializedMemoIdRef.current !== currentMemoId;
+
+			if (isNewMemo) {
+				setValue("memo", memoData?.memo ?? "");
+				initializedMemoIdRef.current = currentMemoId;
+			}
+
 			setValue("isWish", memoData?.isWish ?? false);
 			setValue("categoryId", memoData?.category_id ?? null);
 		},
-		[memoData?.memo, memoData?.isWish, memoData?.category_id, setValue],
+		[memoData?.id, memoData?.memo, memoData?.isWish, memoData?.category_id, setValue],
 	);
 
 	const saveMemo = useCallback(


### PR DESCRIPTION
## 요약
사이드 패널에서 메모 작성 중 커서가 텍스트 끝으로 이동하는 버그를 수정했습니다.

## 문제 원인
- `initMemoData` useEffect에서 `memoData?.memo` 변경을 감지해서 매번 `setValue("memo", ...)` 호출
- 사용자 입력 → saveMemo → DB 업데이트 → useMemoQuery 갱신 → initMemoData 실행 → setValue 호출 → 커서 끝으로 이동

```
사용자 메모 입력
  ↓
handleMemoChange → setValue("memo", text)
  ↓
debounce → saveMemo() → DB 업데이트
  ↓
useMemoQuery → memoData 갱신
  ↓
initMemoData useEffect 실행
  ↓
setValue("memo", memoData?.memo) ← 불필요한 호출로 커서 끝으로 이동!
```

## 변경사항
- `initializedMemoIdRef` 추가 - 이미 초기화된 메모 ID를 추적
- `memo` 값은 새로운 메모(다른 페이지)로 이동했을 때만 `setValue` 호출
- `isWish`와 `categoryId`는 기존처럼 항상 동기화 유지 (다른 곳에서 변경 가능하므로)

## 테스트 계획
- [ ] 메모 입력 중 커서 위치가 유지되는지 확인
- [ ] 다른 페이지로 이동 시 해당 페이지의 메모가 정상 로드되는지 확인
- [ ] isWish 토글 시 정상 동작하는지 확인
- [ ] 카테고리 변경 시 정상 동기화되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)