### PR TITLE
fix: iOS google-signin 빌드 위한 modular headers 설정 추가

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -94,6 +94,12 @@
 				{
 					"android": {
 						"kotlinVersion": "2.0.21"
+					},
+					"ios": {
+						"extraPods": [
+							{ "name": "GoogleUtilities", "modular_headers": true },
+							{ "name": "RecaptchaInterop", "modular_headers": true }
+						]
 					}
 				}
 			],

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
@@ -52,7 +52,13 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 			setValue("isWish", memoData?.isWish ?? false);
 			setValue("categoryId", memoData?.category_id ?? null);
 		},
-		[memoData?.id, memoData?.memo, memoData?.isWish, memoData?.category_id, setValue],
+		[
+			memoData?.id,
+			memoData?.memo,
+			memoData?.isWish,
+			memoData?.category_id,
+			setValue,
+		],
 	);
 
 	const saveMemo = useCallback(


### PR DESCRIPTION
## Summary
- `@react-native-google-signin/google-signin`이 끌어오는 `AppCheckCore`(Swift)가 모듈을 정의하지 않는 `GoogleUtilities`/`RecaptchaInterop`에 의존해, iOS `pod install` 시 "Swift pods cannot be integrated as static libraries" 에러로 빌드가 실패하는 문제를 해결합니다.
- 전역 `use_modular_headers!`는 New Architecture의 C++ pod(folly 등)를 깨뜨릴 수 있어, 공식 `expo-build-properties`의 `ios.extraPods`로 **문제 pod 2개에만** `modular_headers`를 적용했습니다.
- 별도 커스텀 config plugin 없이 이미 사용 중인 플러그인 설정만으로 처리합니다.

## Test plan
- [x] `expo prebuild -p ios` 후 생성된 Podfile에 `pod 'GoogleUtilities'/'RecaptchaInterop', :modular_headers => true` 주입 확인
- [x] `pod install` 성공 (107 dependencies, 117 pods)
- [x] iOS 시뮬레이터(iPhone 17 Pro, iOS 26.5) 빌드·설치·실행 및 앱 UI 렌더링 확인
- [ ] Android 빌드에 영향 없음 (ios 전용 설정)