### PR TITLE
feat: 모바일 앱 네이티브 공유 기능 추가 및 위시리스트 관련 버그 수정

### DIFF
--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -1,4 +1,4 @@
-import { FileText, Globe, HeartOff, X } from "lucide-react-native";
+import { FileText, Globe, HeartOff, Share2, X } from "lucide-react-native";
 import { useCallback, useEffect, useState } from "react";
 import {
 	Dimensions,
@@ -16,6 +16,7 @@ import Animated, {
 	withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { shareUrl } from "@/lib/sharing/shareUrl";
 import { extractDomain } from "../_utils/extractDomain";
 import { formatDate } from "../_utils/formatDate";
 import type { MemoItem } from "./MemoCard";
@@ -76,6 +77,12 @@ export function MemoDetailModal({
 		}
 	}, [memo, onWishRemove]);
 
+	const handleShare = useCallback(() => {
+		if (memo?.url) {
+			shareUrl(memo.url, memo.title);
+		}
+	}, [memo]);
+
 	const title = memo?.title || "Untitled";
 	const memoText = memo?.memo ?? "";
 	const favIconUrl = memo && "favIconUrl" in memo ? memo.favIconUrl : undefined;
@@ -130,6 +137,9 @@ export function MemoDetailModal({
 							>
 								{title}
 							</Text>
+						</TouchableOpacity>
+						<TouchableOpacity onPress={handleShare} activeOpacity={0.7}>
+							<Share2 size={20} color="#666" />
 						</TouchableOpacity>
 						<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
 							<X size={22} color="#666" />

--- a/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
+++ b/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
@@ -4,6 +4,7 @@ import {
 	LayoutGrid,
 	RotateCw,
 	Search,
+	Share2,
 	Star,
 	X,
 } from "lucide-react-native";
@@ -26,6 +27,7 @@ interface BrowserHeaderProps {
 	onOpenBlogSheet: () => void;
 	onFavoriteToggle: () => void;
 	onWishToggle: () => void;
+	onShare: () => void;
 }
 
 export function BrowserHeader({
@@ -41,6 +43,7 @@ export function BrowserHeader({
 	onOpenBlogSheet,
 	onFavoriteToggle,
 	onWishToggle,
+	onShare,
 }: BrowserHeaderProps) {
 	return (
 		<Animated.View className="overflow-hidden" style={headerWrapperStyle}>
@@ -66,6 +69,9 @@ export function BrowserHeader({
 						</TouchableOpacity>
 					)}
 				</View>
+				<TouchableOpacity onPress={onShare} className="p-1.5">
+					<Share2 size={16} color="#111" />
+				</TouchableOpacity>
 				<TouchableOpacity
 					onPress={() => webViewRef.current?.reload()}
 					className="p-1.5"

--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/hooks/useLocalMemos";
 import { useSupabaseMemoByUrl } from "@/lib/hooks/useMemoByUrl";
 import { useMemoWishToggleMutation } from "@/lib/hooks/useMemoMutation";
+import { shareUrl } from "@/lib/sharing/shareUrl";
 import { getPanelRatio, savePanelRatio } from "../_utils/browserPreferences";
 import { formatUrl } from "../_utils/formatUrl";
 import {
@@ -41,7 +42,10 @@ const HIDE_DURATION = 250;
 export function useBrowserState() {
 	const insets = useSafeAreaInsets();
 	const webViewRef = useRef<WebView>(null);
-	const { url: paramUrl } = useLocalSearchParams<{ url?: string }>();
+	const { url: paramUrl, t: navTs } = useLocalSearchParams<{
+		url?: string;
+		t?: string;
+	}>();
 
 	const [currentUrl, setCurrentUrl] = useState("");
 	const [pageTitle, setPageTitle] = useState("");
@@ -92,17 +96,15 @@ export function useBrowserState() {
 		}, [isBrowserActive, tabBarTranslateY, headerTranslateY]),
 	);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: navTs는 동일 url 재진입 시에도 effect를 재실행시키기 위한 네비게이션 nonce
 	useEffect(() => {
-		if (paramUrl) {
-			const decoded = decodeURIComponent(paramUrl);
-			setCurrentUrl(decoded);
-			setPageTitle("");
-			if (isMemoOpen) {
-				setIsMemoOpen(false);
-				panelHeight.value = withSpring(0, SPRING_CONFIG);
-			}
-		}
-	}, [paramUrl, isMemoOpen, panelHeight]);
+		if (!paramUrl) return;
+		const decoded = decodeURIComponent(paramUrl);
+		setCurrentUrl(decoded);
+		setPageTitle("");
+		setIsMemoOpen(false);
+		panelHeight.value = withSpring(0, SPRING_CONFIG);
+	}, [paramUrl, navTs, panelHeight]);
 
 	const handleNavigationStateChange = (navState: WebViewNavigation) => {
 		setCurrentUrl(navState.url);
@@ -267,6 +269,10 @@ export function useBrowserState() {
 		setPageTitle("");
 	}, []);
 
+	const handleShare = useCallback(() => {
+		shareUrl(currentUrl, pageTitle);
+	}, [currentUrl, pageTitle]);
+
 	return {
 		insets,
 		webViewRef,
@@ -296,6 +302,7 @@ export function useBrowserState() {
 		openPanel,
 		closePanel,
 		handleBlogSelect,
+		handleShare,
 		SCROLL_DETECT_JS,
 	};
 }

--- a/apps/app/app/(main)/browser/index.tsx
+++ b/apps/app/app/(main)/browser/index.tsx
@@ -38,6 +38,7 @@ export default function BrowserScreen() {
 		toggleMemo,
 		closePanel,
 		handleBlogSelect,
+		handleShare,
 		SCROLL_DETECT_JS,
 	} = useBrowserState();
 
@@ -75,6 +76,7 @@ export default function BrowserScreen() {
 				onOpenBlogSheet={() => setIsBlogSheetOpen(true)}
 				onFavoriteToggle={handleFavoriteToggle}
 				onWishToggle={handleWishToggle}
+				onShare={handleShare}
 			/>
 
 			<View

--- a/apps/app/app/(main)/index.tsx
+++ b/apps/app/app/(main)/index.tsx
@@ -44,7 +44,7 @@ export default function MemoScreen() {
 		(url: string) => {
 			router.navigate({
 				pathname: "/(main)/browser",
-				params: { url: encodeURIComponent(url) },
+				params: { url: encodeURIComponent(url), t: String(Date.now()) },
 			});
 		},
 		[router],

--- a/apps/app/app/_layout.tsx
+++ b/apps/app/app/_layout.tsx
@@ -1,10 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Stack, useRouter } from "expo-router";
+import { Stack } from "expo-router";
 import { useShareIntent } from "expo-share-intent";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { Check } from "lucide-react-native";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Text, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -60,36 +60,37 @@ function SyncOnAuth() {
 function ShareIntentHandler() {
 	const { hasShareIntent, shareIntent, resetShareIntent } = useShareIntent();
 	const insets = useSafeAreaInsets();
-	const router = useRouter();
 	const [shareToast, setShareToast] = useState<string | null>(null);
+	const processingUrlRef = useRef<string | null>(null);
 
 	useEffect(() => {
-		if (hasShareIntent && shareIntent) {
-			const url = shareIntent.webUrl || shareIntent.text;
-			if (url?.startsWith("http")) {
-				handleSharedUrl(url, shareIntent.meta?.title ?? undefined)
-					.then(() => {
-						queryClient.invalidateQueries({ queryKey: ["memos"] });
-						queryClient.invalidateQueries({ queryKey: ["localMemos"] });
-						setShareToast("위시리스트에 저장되었습니다");
-						setTimeout(() => setShareToast(null), 3000);
-						router.navigate({
-							pathname: "/(main)",
-							params: { filter: "wish" },
-						});
-					})
-					.catch(() => {
-						setShareToast("저장에 실패했습니다");
-						setTimeout(() => setShareToast(null), 3000);
-					})
-					.finally(() => {
-						resetShareIntent();
-					});
-			} else {
-				resetShareIntent();
-			}
+		if (!hasShareIntent || !shareIntent) return;
+
+		const url = shareIntent.webUrl || shareIntent.text;
+		if (!url?.startsWith("http")) {
+			resetShareIntent();
+			return;
 		}
-	}, [hasShareIntent, shareIntent, resetShareIntent, router.navigate]);
+
+		if (processingUrlRef.current === url) return;
+		processingUrlRef.current = url;
+
+		handleSharedUrl(url, shareIntent.meta?.title ?? undefined)
+			.then(() => {
+				queryClient.invalidateQueries({ queryKey: ["memos"] });
+				queryClient.invalidateQueries({ queryKey: ["localMemos"] });
+				setShareToast("위시리스트에 추가되었습니다");
+				setTimeout(() => setShareToast(null), 3000);
+			})
+			.catch(() => {
+				setShareToast("저장에 실패했습니다");
+				setTimeout(() => setShareToast(null), 3000);
+			})
+			.finally(() => {
+				processingUrlRef.current = null;
+				resetShareIntent();
+			});
+	}, [hasShareIntent, shareIntent, resetShareIntent]);
 
 	if (!shareToast) return null;
 

--- a/apps/app/lib/sharing/shareUrl.ts
+++ b/apps/app/lib/sharing/shareUrl.ts
@@ -1,0 +1,13 @@
+import { Share } from "react-native";
+
+/**
+ * 네이티브 공유 시트를 열어 페이지 제목과 URL을 공유한다.
+ * 카카오톡·메모 등 OS가 제공하는 공유 대상이 시트에 자동으로 노출된다.
+ */
+export async function shareUrl(url: string, title?: string): Promise<void> {
+	if (!url) return;
+	const message = title ? `${title}\n${url}` : url;
+	try {
+		await Share.share({ message });
+	} catch {}
+}

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
@@ -52,7 +52,13 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 			setValue("isWish", memoData?.isWish ?? false);
 			setValue("categoryId", memoData?.category_id ?? null);
 		},
-		[memoData?.id, memoData?.memo, memoData?.isWish, memoData?.category_id, setValue],
+		[
+			memoData?.id,
+			memoData?.memo,
+			memoData?.isWish,
+			memoData?.category_id,
+			setValue,
+		],
 	);
 
 	const saveMemo = useCallback(


### PR DESCRIPTION
## Summary
- 브라우저 헤더(URL 옆)와 메모 상세 모달에 **네이티브 공유 버튼** 추가 — RN `Share` API로 `제목+URL`을 OS 공유 시트(카카오톡·메모 등)에 전달
- **위시리스트 메모 클릭 시 사이트로 이동되지 않던 버그** 수정 — 브라우저 이동에 timestamp nonce를 전달해 동일 URL 재진입에서도 항상 로드되도록 개선
- **타서비스 공유 저장 시 버그 2건** 수정 — ① 공유 인텐트 동시 처리로 인한 중복 추가를 ref 가드로 방지, ② 저장 후 위시리스트 화면으로 강제 이동하던 동작 제거하고 `'위시리스트에 추가되었습니다'` 토스트만 표시

## 변경 파일
- `apps/app/lib/sharing/shareUrl.ts` (신규) — 네이티브 공유 유틸
- `apps/app/app/(main)/browser/_components/BrowserHeader.tsx` — 공유 버튼
- `apps/app/app/(main)/browser/_hooks/useBrowserState.ts` — `handleShare` + url 파라미터 effect nonce 재구성
- `apps/app/app/(main)/browser/index.tsx` — 공유 핸들러 연결
- `apps/app/app/(main)/_components/MemoDetailModal.tsx` — 모달 공유 버튼
- `apps/app/app/(main)/index.tsx` — 브라우저 이동 시 nonce 전달
- `apps/app/app/_layout.tsx` — 공유 인텐트 중복 방지 + 토스트/이동 처리

## Test plan
- [ ] 브라우저에서 페이지 열고 헤더 공유 버튼 → 네이티브 공유 시트에 제목+URL 표시
- [ ] 메모 상세 모달의 공유 버튼 → 해당 메모 URL 공유
- [ ] 위시리스트에서 메모 클릭 → 해당 사이트로 이동, 동일 메모 재클릭 시에도 재이동
- [ ] 타서비스에서 웹메모로 공유 → 위시리스트에 1개만 추가, 화면 이동 없이 '위시리스트에 추가되었습니다' 토스트 표시
- [ ] 동일 URL 반복 공유 시 중복 추가되지 않는지 확인