### PR TITLE
ci: iOS 빌드 번호 자동 증가 및 TestFlight 자동 제출 설정

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -38,3 +38,13 @@ jobs:
           name: ios-build
           path: apps/app/build.ipa
           retention-days: 7
+
+      - name: Write App Store Connect API key
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+        env:
+          ASC_API_KEY_P8: ${{ secrets.EXPO_ASC_API_KEY_P8 }}
+        run: echo "$ASC_API_KEY_P8" > apps/app/asc-api-key.p8
+
+      - name: Submit to TestFlight
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+        run: cd apps/app && eas submit --platform ios --profile production --path ./build.ipa --non-interactive

--- a/apps/app/.gitignore
+++ b/apps/app/.gitignore
@@ -8,6 +8,7 @@ dist/
 *.p12
 *.key
 *.mobileprovision
+*.ipa
 *.orig.*
 web-build/
 

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -17,7 +17,7 @@
 		"ios": {
 			"supportsTablet": true,
 			"bundleIdentifier": "com.webmemo.app",
-			"buildNumber": "2",
+			"buildNumber": "3",
 			"usesAppleSignIn": true,
 			"infoPlist": {
 				"ITSAppUsesNonExemptEncryption": false,

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -3,7 +3,7 @@
 		"name": "Web Memo",
 		"slug": "web-memo",
 		"owner": "guesung",
-		"version": "1.0.4",
+		"version": "1.0.5",
 		"orientation": "portrait",
 		"icon": "./assets/icon.png",
 		"scheme": "webmemo",
@@ -17,7 +17,7 @@
 		"ios": {
 			"supportsTablet": true,
 			"bundleIdentifier": "com.webmemo.app",
-			"buildNumber": "3",
+			"buildNumber": "4",
 			"usesAppleSignIn": true,
 			"infoPlist": {
 				"ITSAppUsesNonExemptEncryption": false,

--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -11,7 +11,9 @@
 		"preview": {
 			"distribution": "internal"
 		},
-		"production": {},
+		"production": {
+			"autoIncrement": true
+		},
 		"ci": {
 			"distribution": "store",
 			"env": {

--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -22,6 +22,13 @@
 		}
 	},
 	"submit": {
-		"production": {}
+		"production": {
+			"ios": {
+				"ascApiKeyPath": "./asc-api-key.p8",
+				"ascApiKeyId": "HT774VM4W5",
+				"ascApiKeyIssuerId": "ab5c73bd-ddb0-44a7-9797-941c1a211615",
+				"ascAppId": "6759237784"
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `eas.json` production 빌드 프로파일에 `autoIncrement: true` 추가 — 빌드 번호 자동 증가로 TestFlight 중복 충돌 방지
- `cd-app` 워크플로에 **TestFlight 자동 제출(`eas submit`) 단계** 추가 — `develop`/`master` push에서만 실행(PR은 빌드만)
  - App Store Connect API 키(.p8)는 `EXPO_ASC_API_KEY_P8` 시크릿에서 주입, eas.json submit 프로파일에 Key ID/Issuer ID/ascAppId 설정
- 앱 버전 `1.0.4 → 1.0.5` 상향 (1.0.4 트레인이 닫혀 동일 버전 재업로드 불가), buildNumber 4
- `.gitignore`에 `*.ipa` 추가 (로컬 빌드 산출물 커밋 방지)

## 변경 파일
- `apps/app/eas.json` — autoIncrement + submit(iOS) 프로파일
- `.github/workflows/cd-app.yml` — eas submit 단계(브랜치 게이팅)
- `apps/app/app.json` — version 1.0.5 / buildNumber 4
- `apps/app/.gitignore` — *.ipa

## Test plan
- [ ] PR에서는 cd-app이 빌드만 하고 제출하지 않는지 확인
- [ ] develop/master push 시 빌드 후 TestFlight 제출까지 수행되는지 확인
- [ ] 제출된 빌드가 App Store Connect에 정상 표시되는지 확인

## 참고 / 후속
- CI 환경(`appVersionSource: local`)에서는 autoIncrement 값이 커밋으로 되돌아오지 않아, 같은 버전으로 여러 번 push하면 빌드 번호가 충돌할 수 있음. 완전 자동화가 필요하면 `appVersionSource: remote`(EAS가 빌드 번호 관리) 전환 검토 필요.