### PR TITLE
feat: 브라우저 탭에서 위시리스트 취소 시 빈 메모 삭제

### DIFF
--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -19,10 +19,14 @@ import { useBrowserScroll } from "@/lib/context/BrowserScrollContext";
 import { useFavoriteToggle, useIsFavorite } from "@/lib/hooks/useFavorites";
 import {
 	useLocalMemoByUrl,
+	useLocalMemoDelete,
 	useLocalMemoWishToggle,
 } from "@/lib/hooks/useLocalMemos";
 import { useSupabaseMemoByUrl } from "@/lib/hooks/useMemoByUrl";
-import { useMemoWishToggleMutation } from "@/lib/hooks/useMemoMutation";
+import {
+	useDeleteMemoMutation,
+	useMemoWishToggleMutation,
+} from "@/lib/hooks/useMemoMutation";
 import { shareUrl } from "@/lib/sharing/shareUrl";
 import { getPanelRatio, savePanelRatio } from "../_utils/browserPreferences";
 import { formatUrl } from "../_utils/formatUrl";
@@ -65,6 +69,8 @@ export function useBrowserState() {
 	const { data: localMemo } = useLocalMemoByUrl(currentUrl);
 	const wishToggleSupabase = useMemoWishToggleMutation();
 	const wishToggleLocal = useLocalMemoWishToggle();
+	const deleteSupabaseMemo = useDeleteMemoMutation();
+	const deleteLocalMemo = useLocalMemoDelete();
 
 	const isCurrentPageWish = isLoggedIn
 		? (supabaseMemo?.isWish ?? false)
@@ -152,20 +158,35 @@ export function useBrowserState() {
 
 	const handleWishToggle = useCallback(() => {
 		Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
+		// 위시리스트를 취소할 때, 작성된 메모가 없으면 메모 레코드를 삭제한다
+		const currentMemo = isLoggedIn ? supabaseMemo : localMemo;
+		const shouldDeleteEmptyMemo =
+			isCurrentPageWish && !currentMemo?.memo?.trim();
+
 		if (isLoggedIn) {
-			wishToggleSupabase.mutate({
-				url: currentUrl,
-				title: pageTitle,
-				favIconUrl: pageFavIconUrl,
-				currentIsWish: isCurrentPageWish,
-			});
+			if (shouldDeleteEmptyMemo && supabaseMemo) {
+				deleteSupabaseMemo.mutate(supabaseMemo.id);
+			} else {
+				wishToggleSupabase.mutate({
+					url: currentUrl,
+					title: pageTitle,
+					favIconUrl: pageFavIconUrl,
+					currentIsWish: isCurrentPageWish,
+				});
+			}
 		} else {
-			wishToggleLocal.mutate({
-				url: currentUrl,
-				title: pageTitle,
-				favIconUrl: pageFavIconUrl,
-			});
+			if (shouldDeleteEmptyMemo && localMemo) {
+				deleteLocalMemo.mutate(localMemo.id);
+			} else {
+				wishToggleLocal.mutate({
+					url: currentUrl,
+					title: pageTitle,
+					favIconUrl: pageFavIconUrl,
+				});
+			}
 		}
+
 		setWishToast(
 			isCurrentPageWish ? "위시리스트에서 제거" : "위시리스트에 추가",
 		);
@@ -176,8 +197,12 @@ export function useBrowserState() {
 		pageFavIconUrl,
 		isLoggedIn,
 		isCurrentPageWish,
+		supabaseMemo,
+		localMemo,
 		wishToggleSupabase,
 		wishToggleLocal,
+		deleteSupabaseMemo,
+		deleteLocalMemo,
 	]);
 
 	const openPanel = useCallback(() => {

--- a/apps/app/lib/hooks/useLocalMemos.ts
+++ b/apps/app/lib/hooks/useLocalMemos.ts
@@ -71,6 +71,7 @@ export function useLocalMemoDelete() {
 		mutationFn: deleteMemo,
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: QUERY_KEY.localMemos() });
+			queryClient.invalidateQueries({ queryKey: ["localMemo"] });
 		},
 	});
 }

--- a/apps/app/lib/hooks/useMemoMutation.ts
+++ b/apps/app/lib/hooks/useMemoMutation.ts
@@ -42,6 +42,7 @@ export function useDeleteMemoMutation() {
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: QUERY_KEY.memos() });
+			queryClient.invalidateQueries({ queryKey: ["memo"] });
 		},
 	});
 }


### PR DESCRIPTION
## Summary
- 브라우저 탭에서 위시리스트를 **취소**할 때, 작성된 메모 본문이 없으면 위시 플래그만 끄는 대신 메모 레코드 자체를 삭제하도록 변경 (로그인=Supabase / 비로그인=로컬 각각 처리). 위시만 켰다 끈 빈 레코드가 목록에 남지 않습니다.
- 메모 삭제 mutation(`useDeleteMemoMutation`, `useLocalMemoDelete`) 성공 시 by-url 쿼리(`["memo"]`, `["localMemo"]`)도 무효화하여, 삭제 직후 하트 아이콘이 즉시 갱신되도록 보강.

## Test plan
- [ ] 비로그인: 브라우저에서 페이지 위시 추가 → 메모 미작성 상태로 위시 취소 → 목록에 해당 레코드가 남지 않음
- [ ] 비로그인: 메모를 작성한 페이지의 위시 취소 → 메모는 유지되고 위시 플래그만 해제됨
- [ ] 로그인: 위 두 시나리오 동일하게 동작 (Supabase)
- [ ] 위시 취소 후 하트 아이콘이 즉시 빈 상태로 갱신됨
- [ ] `pnpm type-check` 통과