### PR TITLE
fix: 새 창을 열어도 사이드 패널이 자기 창의 메모를 유지하도록 수정

### DIFF
--- a/packages/shared/src/utils/extension/module/Tab.test.ts
+++ b/packages/shared/src/utils/extension/module/Tab.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { Tab } from "./Tab";
+
+describe("Tab.get", () => {
+	const queryMock = vi.fn();
+
+	beforeEach(() => {
+		queryMock.mockReset();
+		vi.stubGlobal("chrome", {
+			tabs: { query: queryMock },
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test("현재 창(사이드 패널이 속한 창)의 활성 탭을 조회한다.", async () => {
+		// 사이드 패널은 각 창마다 별도 인스턴스로 동작하므로, 마지막으로 포커스된 창이 아니라
+		// 자신이 속한 창(currentWindow)의 활성 탭을 가져와야 한다.
+		const ownWindowTab = { id: 1, url: "https://own-window.example" };
+		queryMock.mockResolvedValue([ownWindowTab]);
+
+		const tab = await Tab.get();
+
+		expect(queryMock).toHaveBeenCalledWith({
+			active: true,
+			currentWindow: true,
+		});
+		expect(tab).toBe(ownWindowTab);
+	});
+});

--- a/packages/shared/src/utils/extension/module/Tab.ts
+++ b/packages/shared/src/utils/extension/module/Tab.ts
@@ -5,9 +5,12 @@ import type {
 
 export class Tab {
 	static async get() {
+		// 사이드 패널은 창마다 별도 인스턴스로 동작한다. lastFocusedWindow를 쓰면
+		// 새 창을 열었을 때 기존 창의 사이드 패널이 새 창의 활성 탭을 가져오므로,
+		// 자신이 속한 창(currentWindow)의 활성 탭을 조회해야 한다.
 		const [tab] = await chrome.tabs.query({
 			active: true,
-			lastFocusedWindow: true,
+			currentWindow: true,
 		});
 		return tab;
 	}


### PR DESCRIPTION
## 개요

확장 프로그램에서 **새 창을 열면 기존 창의 사이드 패널이 새 창의 URL 메모로 바뀌던 문제**를 수정합니다.

## 원인

사이드 패널은 글로벌 패널이라 **창마다 별도 인스턴스**로 뜹니다. 그런데 현재 탭을 조회하는 `Tab.get()`이 `chrome.tabs.query({ active: true, lastFocusedWindow: true })`를 사용하고 있었습니다.

- 새 창을 열면 background의 `chrome.tabs.onActivated`가 발생 → `UPDATE_SIDE_PANEL`을 **모든 창의 사이드 패널에 브로드캐스트**
- 기존 창의 패널도 `Tab.get()`을 다시 호출하는데, `lastFocusedWindow`는 "가장 최근 포커스된 창"(= 방금 연 새 창)을 가리켜 새 창의 탭 URL 메모로 바뀜

## 변경 사항

- `Tab.get()`의 쿼리를 `lastFocusedWindow: true` → `currentWindow: true`로 변경
  - 각 사이드 패널이 **자신이 속한 창의 활성 탭**을 조회하게 됨
  - `useTabQuery`(표시 메모 결정), `getTabInfo`(메모 저장), `Tab.sendMessage`(PAGE_CONTENT) 모두 이 함수를 사용하므로 한 곳 수정으로 일괄 반영
- 회귀 테스트 추가 (`Tab.test.ts`): `Tab.get()`이 `currentWindow`로 조회하는지 검증

## 동작

- 새 창을 열어도 기존 창의 패널은 **자기 창 탭의 메모를 유지** ✅
- 한 창 안에서 탭을 전환하면 그 창의 패널은 정상적으로 따라감 ✅

## 검증

- 신규/기존 테스트 전체 통과 (14/14)
- `pnpm type-check` 통과 (14/14)
- 변경 파일 lint 클린

> ⚠️ 실제 Chrome 멀티 창 라이브 검증은 아직 하지 않았습니다. 단위 테스트 + Chrome 문서(`currentWindow` vs `lastFocusedWindow` 의미) + 아키텍처 분석 기반입니다.
