### PR TITLE
fix: 메모 작성 다이얼로그 긴 메모 스크롤 수정

### DIFF
--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -121,7 +121,7 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 		<>
 			<Dialog open>
 				<DialogContent
-					className="max-w-[600px] p-0"
+					className="max-h-[90dvh] max-w-[600px] overflow-y-auto p-0"
 					onClose={checkEditedAndCloseDialog}
 				>
 					<motion.div


### PR DESCRIPTION
## 변경 요약

메모 작성 다이얼로그에서 메모가 길어지면 스크롤이 내려가지 않아 넘친 내용·푸터에 접근할 수 없던 문제를 수정합니다.

## 원인

- 메모 `Textarea`는 자동 높이 조절(`adjustTextareaHeight`: `height = scrollHeight`)로 내용만큼 무한히 늘어나 자체 스크롤이 없음
- 이를 감싼 `DialogContent`에 높이 제한·`overflow`가 없어, `fixed`로 화면 중앙에 고정된 다이얼로그가 화면 밖으로 넘쳐도 스크롤 컨테이너가 없어 도달 불가

## 변경점

- `MemoDialog`의 `DialogContent`에 `max-h-[90dvh] overflow-y-auto` 추가 → 메모가 길어지면 다이얼로그 내부에 스크롤이 생기고, 타이핑 시 커서를 따라 자동 스크롤됨
- 공용 `Dialog` 컴포넌트가 아닌 메모 다이얼로그에만 적용해 다른 화면 영향 없음

## 검증

- `pnpm type-check` 통과 (14/14)
- `pnpm lint` 통과
