### PR TITLE
fix: 앱 브라우저 즐겨찾기 아이콘을 별표에서 북마크로 변경

### DIFF
--- a/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
+++ b/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
@@ -1,11 +1,11 @@
 import {
+	Bookmark,
 	Heart,
 	Home,
 	LayoutGrid,
 	RotateCw,
 	Search,
 	Share2,
-	Star,
 	X,
 } from "lucide-react-native";
 import { TextInput, TouchableOpacity, View } from "react-native";
@@ -85,7 +85,7 @@ export function BrowserHeader({
 					<LayoutGrid size={16} color="#111" />
 				</TouchableOpacity>
 				<TouchableOpacity onPress={onFavoriteToggle} className="p-1.5">
-					<Star
+					<Bookmark
 						size={16}
 						color={isCurrentPageFavorite ? "#f59e0b" : "#111"}
 						fill={isCurrentPageFavorite ? "#f59e0b" : "none"}

--- a/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
@@ -1,4 +1,4 @@
-import { Star } from "lucide-react-native";
+import { Bookmark } from "lucide-react-native";
 import { useState } from "react";
 import {
 	Alert,
@@ -25,7 +25,7 @@ export function FavoriteLinks({ onSelectUrl }: FavoriteLinksProps) {
 					즐겨찾기
 				</Text>
 				<View className="items-center py-6 bg-card rounded-xl border border-border">
-					<Star size={24} color="#ddd" />
+					<Bookmark size={24} color="#ddd" />
 					<Text className="text-[13px] text-muted-foreground mt-2">
 						자주 방문하는 페이지를 즐겨찾기에 추가해보세요
 					</Text>

--- a/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { URL as APP_URL } from "@web-memo/shared/constants";
-import { MessageCircle, Star, X } from "lucide-react-native";
+import { Bookmark, MessageCircle, X } from "lucide-react-native";
 import { useEffect, useState } from "react";
 import {
 	Alert,
@@ -192,7 +192,7 @@ function FavoritesSection({ onPress }: { onPress: (url: string) => void }) {
 	return (
 		<>
 			<View className="flex-row items-center gap-1.5 px-2 mb-3">
-				<Star size={14} color="#f59e0b" fill="#f59e0b" />
+				<Bookmark size={14} color="#f59e0b" fill="#f59e0b" />
 				<Text className="text-sm font-semibold text-gray-500">즐겨찾기</Text>
 			</View>
 			<View className="mb-6">


### PR DESCRIPTION
## 작업 내용
앱(React Native)에서 "브라우저 즐겨찾기"에 쓰이던 별표(`Star`, ⭐) 아이콘을 북마크(`Bookmark`, 🔖)로 변경했습니다.

기존에는 같은 `Star` 아이콘이 두 가지 의미로 중복 사용되어 혼란을 주었습니다:
- 메모 **중요**(`isStar`) 표시 → ⭐
- 브라우저 **즐겨찾기**(로컬 Favorite) → ⭐ (동일)

이번 변경으로 브라우저 즐겨찾기는 🔖, 메모 중요는 ⭐로 시각적으로 구분됩니다.

## 변경 사항
- `apps/app/app/(main)/browser/_components/BrowserHeader.tsx` — 헤더 즐겨찾기 토글 `Star`→`Bookmark`
- `apps/app/app/(main)/browser/_components/FavoriteLinks.tsx` — 빈 상태 아이콘 `Star`→`Bookmark`
- `apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx` — "즐겨찾기" 섹션 라벨 `Star`→`Bookmark`
- 아이콘 props(`size`/`color`/`fill`)와 색상값은 그대로 유지. 메모 중요(`isStar`)용 `Star`/`StarOff`는 미변경.

## 영향 범위
- 앱 한정. 데이터 모델/마이그레이션 변경 없음.

## 테스트
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] 앱 실행 시각 확인(헤더/빈 상태/섹션 라벨 🔖, 메모 카드 중요 배지 ⭐ 유지)
