### PR TITLE
feat: 메모에 느낀 점·액션 아이템 섹션 추가 (메모/느낀 점/액션 아이템)

### DIFF
--- a/apps/app/app/(main)/_components/MemoCard.tsx
+++ b/apps/app/app/(main)/_components/MemoCard.tsx
@@ -96,6 +96,22 @@ export function MemoCard({ memo, onPress, onDelete }: MemoCardProps) {
 						{memo.memo}
 					</Text>
 				)}
+				{memo.impression ? (
+					<Text
+						className="text-sm text-secondary-foreground leading-5 mb-1.5"
+						numberOfLines={4}
+					>
+						느낀 점: {memo.impression}
+					</Text>
+				) : null}
+				{memo.actionItem ? (
+					<Text
+						className="text-sm text-secondary-foreground leading-5 mb-1.5"
+						numberOfLines={4}
+					>
+						액션 아이템: {memo.actionItem}
+					</Text>
+				) : null}
 			</TouchableOpacity>
 		</ReanimatedSwipeable>
 	);

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -173,14 +173,22 @@ export function MemoDetailModal({
 						</Text>
 						{memo?.impression ? (
 							<View className="mt-3">
-								<Text className="text-xs font-semibold text-gray-500 mb-1">느낀 점</Text>
-								<Text className="text-[15px] text-[#333] leading-[22px]">{memo.impression}</Text>
+								<Text className="text-xs font-semibold text-gray-500 mb-1">
+									느낀 점
+								</Text>
+								<Text className="text-[15px] text-[#333] leading-[22px]">
+									{memo.impression}
+								</Text>
 							</View>
 						) : null}
 						{memo?.actionItem ? (
 							<View className="mt-3">
-								<Text className="text-xs font-semibold text-gray-500 mb-1">액션 아이템</Text>
-								<Text className="text-[15px] text-[#333] leading-[22px]">{memo.actionItem}</Text>
+								<Text className="text-xs font-semibold text-gray-500 mb-1">
+									액션 아이템
+								</Text>
+								<Text className="text-[15px] text-[#333] leading-[22px]">
+									{memo.actionItem}
+								</Text>
 							</View>
 						) : null}
 					</ScrollView>

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -171,6 +171,18 @@ export function MemoDetailModal({
 						<Text className="text-[15px] text-[#333] leading-[22px]">
 							{memoText}
 						</Text>
+						{memo?.impression ? (
+							<View className="mt-3">
+								<Text className="text-xs font-semibold text-gray-500 mb-1">느낀 점</Text>
+								<Text className="text-[15px] text-[#333] leading-[22px]">{memo.impression}</Text>
+							</View>
+						) : null}
+						{memo?.actionItem ? (
+							<View className="mt-3">
+								<Text className="text-xs font-semibold text-gray-500 mb-1">액션 아이템</Text>
+								<Text className="text-[15px] text-[#333] leading-[22px]">{memo.actionItem}</Text>
+							</View>
+						) : null}
 					</ScrollView>
 
 					<View className="flex-row items-center justify-between px-5 pt-2 pb-1">

--- a/apps/app/app/(main)/_hooks/useDeleteWithUndo.ts
+++ b/apps/app/app/(main)/_hooks/useDeleteWithUndo.ts
@@ -43,6 +43,8 @@ export function useDeleteWithUndo() {
 				url: m.url,
 				title: m.title,
 				memo: m.memo ?? "",
+				impression: m.impression ?? undefined,
+				actionItem: m.actionItem ?? undefined,
 				favIconUrl: m.favIconUrl ?? undefined,
 				isWish: m.isWish ?? false,
 			});
@@ -52,6 +54,8 @@ export function useDeleteWithUndo() {
 				url: m.url,
 				title: m.title,
 				memo: m.memo,
+				impression: m.impression,
+				actionItem: m.actionItem,
 				favIconUrl: m.favIconUrl,
 				isWish: m.isWish,
 			});

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -97,7 +97,12 @@ export function MemoPanel({
 		if (!justSavedRef.current) {
 			setSaved(false);
 		}
-	}, [existingMemo?.memo, existingMemo?.impression, existingMemo?.actionItem, url]);
+	}, [
+		existingMemo?.memo,
+		existingMemo?.impression,
+		existingMemo?.actionItem,
+		url,
+	]);
 
 	const onSaveSuccess = () => {
 		justSavedRef.current = true;
@@ -109,7 +114,8 @@ export function MemoPanel({
 	};
 
 	const handleSave = () => {
-		if (!memoText.trim() && !impressionText.trim() && !actionItemText.trim()) return;
+		if (!memoText.trim() && !impressionText.trim() && !actionItemText.trim())
+			return;
 
 		if (isLoggedIn) {
 			const payload = {
@@ -177,7 +183,12 @@ export function MemoPanel({
 					<TouchableOpacity
 						className={`flex-row items-center gap-1.5 px-3.5 py-2 rounded-lg ${saved ? "bg-success" : "bg-foreground"}`}
 						onPress={handleSave}
-						disabled={isPending || (!memoText.trim() && !impressionText.trim() && !actionItemText.trim())}
+						disabled={
+							isPending ||
+							(!memoText.trim() &&
+								!impressionText.trim() &&
+								!actionItemText.trim())
+						}
 					>
 						{isPending ? (
 							<ActivityIndicator size="small" color="#fff" />
@@ -212,7 +223,9 @@ export function MemoPanel({
 				textAlignVertical="top"
 			/>
 
-			<Text className="mt-3 text-xs font-semibold text-gray-500">액션 아이템</Text>
+			<Text className="mt-3 text-xs font-semibold text-gray-500">
+				액션 아이템
+			</Text>
 			<TextInput
 				className="text-[15px] text-[#333] leading-[22px]"
 				placeholder="이 페이지를 보고 할 일을 적어보세요"

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -35,6 +35,8 @@ export function MemoPanel({
 	const { isLoggedIn } = useAuth();
 
 	const [memoText, setMemoText] = useState("");
+	const [impressionText, setImpressionText] = useState("");
+	const [actionItemText, setActionItemText] = useState("");
 	const [saved, setSaved] = useState(false);
 	const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
@@ -42,7 +44,11 @@ export function MemoPanel({
 	const { data: supabaseMemo } = useSupabaseMemoByUrl(url, isLoggedIn);
 	const existingMemo = isLoggedIn
 		? supabaseMemo
-			? { memo: supabaseMemo.memo }
+			? {
+					memo: supabaseMemo.memo,
+					impression: supabaseMemo.impression ?? "",
+					actionItem: supabaseMemo.actionItem ?? "",
+				}
 			: null
 		: localMemo;
 
@@ -86,10 +92,12 @@ export function MemoPanel({
 		} else {
 			setMemoText("");
 		}
+		setImpressionText(existingMemo?.impression ?? "");
+		setActionItemText(existingMemo?.actionItem ?? "");
 		if (!justSavedRef.current) {
 			setSaved(false);
 		}
-	}, [existingMemo?.memo, url]);
+	}, [existingMemo?.memo, existingMemo?.impression, existingMemo?.actionItem, url]);
 
 	const onSaveSuccess = () => {
 		justSavedRef.current = true;
@@ -101,13 +109,15 @@ export function MemoPanel({
 	};
 
 	const handleSave = () => {
-		if (!memoText.trim()) return;
+		if (!memoText.trim() && !impressionText.trim() && !actionItemText.trim()) return;
 
 		if (isLoggedIn) {
 			const payload = {
 				url,
 				title: pageTitle || url,
 				memo: memoText.trim(),
+				impression: impressionText.trim(),
+				actionItem: actionItemText.trim(),
 				favIconUrl: favIconUrl ?? null,
 			};
 			supabaseUpsert.mutate(payload, { onSuccess: onSaveSuccess });
@@ -116,6 +126,8 @@ export function MemoPanel({
 				url,
 				title: pageTitle || url,
 				memo: memoText.trim(),
+				impression: impressionText.trim(),
+				actionItem: actionItemText.trim(),
 				favIconUrl,
 			};
 			localUpsert.mutate(payload, { onSuccess: onSaveSuccess });
@@ -126,8 +138,7 @@ export function MemoPanel({
 		<ScrollView
 			className="flex-1 bg-white p-3"
 			keyboardShouldPersistTaps="handled"
-			scrollEnabled={false}
-			contentContainerStyle={{ flex: 1 }}
+			contentContainerStyle={{ flexGrow: 1 }}
 		>
 			<View className="flex-row justify-between items-center mb-2">
 				<View className="flex-row items-center gap-1.5 flex-1 mr-2">
@@ -166,7 +177,7 @@ export function MemoPanel({
 					<TouchableOpacity
 						className={`flex-row items-center gap-1.5 px-3.5 py-2 rounded-lg ${saved ? "bg-success" : "bg-foreground"}`}
 						onPress={handleSave}
-						disabled={isPending || !memoText.trim()}
+						disabled={isPending || (!memoText.trim() && !impressionText.trim() && !actionItemText.trim())}
 					>
 						{isPending ? (
 							<ActivityIndicator size="small" color="#fff" />
@@ -187,6 +198,26 @@ export function MemoPanel({
 				placeholder="이 페이지에 대한 메모를 작성하세요..."
 				value={memoText}
 				onChangeText={setMemoText}
+				multiline
+				textAlignVertical="top"
+			/>
+
+			<Text className="mt-3 text-xs font-semibold text-gray-500">느낀 점</Text>
+			<TextInput
+				className="text-[15px] text-[#333] leading-[22px]"
+				placeholder="이 페이지에서 느낀 점을 적어보세요"
+				value={impressionText}
+				onChangeText={setImpressionText}
+				multiline
+				textAlignVertical="top"
+			/>
+
+			<Text className="mt-3 text-xs font-semibold text-gray-500">액션 아이템</Text>
+			<TextInput
+				className="text-[15px] text-[#333] leading-[22px]"
+				placeholder="이 페이지를 보고 할 일을 적어보세요"
+				value={actionItemText}
+				onChangeText={setActionItemText}
 				multiline
 				textAlignVertical="top"
 			/>

--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -163,7 +163,11 @@ export function useBrowserState() {
 		// 별표만 켜진 빈 메모는 삭제하면 중요 표시가 유실되므로 위시 플래그만 해제한다.
 		const currentMemo = isLoggedIn ? supabaseMemo : localMemo;
 		const shouldDeleteEmptyMemo =
-			isCurrentPageWish && !currentMemo?.memo?.trim() && !currentMemo?.isStar;
+			isCurrentPageWish &&
+			!currentMemo?.memo?.trim() &&
+			!currentMemo?.impression?.trim() &&
+			!currentMemo?.actionItem?.trim() &&
+			!currentMemo?.isStar;
 
 		const wishToastMessage = isCurrentPageWish
 			? "위시리스트에서 제거"

--- a/apps/app/lib/storage/localMemo.ts
+++ b/apps/app/lib/storage/localMemo.ts
@@ -56,8 +56,8 @@ export async function upsertMemo(params: {
 	if (existing) {
 		existing.title = params.title;
 		existing.memo = params.memo;
-		existing.impression = params.impression;
-		existing.actionItem = params.actionItem;
+		if (params.impression !== undefined) existing.impression = params.impression;
+		if (params.actionItem !== undefined) existing.actionItem = params.actionItem;
 		if (params.favIconUrl) existing.favIconUrl = params.favIconUrl;
 		if (params.isWish !== undefined) existing.isWish = params.isWish;
 		if (params.isStar !== undefined) existing.isStar = params.isStar;

--- a/apps/app/lib/storage/localMemo.ts
+++ b/apps/app/lib/storage/localMemo.ts
@@ -7,6 +7,8 @@ export interface LocalMemo {
 	url: string;
 	title: string;
 	memo: string;
+	impression?: string;
+	actionItem?: string;
 	favIconUrl?: string;
 	createdAt: string;
 	updatedAt: string;
@@ -41,6 +43,8 @@ export async function upsertMemo(params: {
 	url: string;
 	title: string;
 	memo: string;
+	impression?: string;
+	actionItem?: string;
 	favIconUrl?: string;
 	isWish?: boolean;
 	isStar?: boolean;
@@ -52,6 +56,8 @@ export async function upsertMemo(params: {
 	if (existing) {
 		existing.title = params.title;
 		existing.memo = params.memo;
+		existing.impression = params.impression;
+		existing.actionItem = params.actionItem;
 		if (params.favIconUrl) existing.favIconUrl = params.favIconUrl;
 		if (params.isWish !== undefined) existing.isWish = params.isWish;
 		if (params.isStar !== undefined) existing.isStar = params.isStar;
@@ -66,6 +72,8 @@ export async function upsertMemo(params: {
 		url: params.url,
 		title: params.title,
 		memo: params.memo,
+		impression: params.impression,
+		actionItem: params.actionItem,
 		favIconUrl: params.favIconUrl,
 		isWish: params.isWish,
 		isStar: params.isStar,

--- a/apps/app/lib/storage/localMemo.ts
+++ b/apps/app/lib/storage/localMemo.ts
@@ -56,8 +56,10 @@ export async function upsertMemo(params: {
 	if (existing) {
 		existing.title = params.title;
 		existing.memo = params.memo;
-		if (params.impression !== undefined) existing.impression = params.impression;
-		if (params.actionItem !== undefined) existing.actionItem = params.actionItem;
+		if (params.impression !== undefined)
+			existing.impression = params.impression;
+		if (params.actionItem !== undefined)
+			existing.actionItem = params.actionItem;
 		if (params.favIconUrl) existing.favIconUrl = params.favIconUrl;
 		if (params.isWish !== undefined) existing.isWish = params.isWish;
 		if (params.isStar !== undefined) existing.isStar = params.isStar;

--- a/apps/app/lib/storage/syncService.ts
+++ b/apps/app/lib/storage/syncService.ts
@@ -30,6 +30,8 @@ export async function syncMemosToSupabase(): Promise<{
 						url: memo.url,
 						title: memo.title,
 						memo: memo.memo,
+						impression: memo.impression ?? null,
+						actionItem: memo.actionItem ?? null,
 						favIconUrl: memo.favIconUrl ?? null,
 						isWish: memo.isWish ?? existing.data[0].isWish,
 					},
@@ -39,6 +41,8 @@ export async function syncMemosToSupabase(): Promise<{
 					url: memo.url,
 					title: memo.title,
 					memo: memo.memo,
+					impression: memo.impression ?? null,
+					actionItem: memo.actionItem ?? null,
 					favIconUrl: memo.favIconUrl ?? null,
 					isWish: memo.isWish ?? false,
 				});

--- a/apps/chrome-extension/public/_locales/en/messages.json
+++ b/apps/chrome-extension/public/_locales/en/messages.json
@@ -169,5 +169,9 @@
 	},
 	"summary_empty_message": {
 		"message": "Click the refresh button above\nto generate a summary"
-	}
+	},
+	"impression": { "message": "Impression" },
+	"impressionPlaceholder": { "message": "Write what you felt about this page" },
+	"actionItem": { "message": "Action items" },
+	"actionItemPlaceholder": { "message": "Write what to do after reading this page" }
 }

--- a/apps/chrome-extension/public/_locales/ko/messages.json
+++ b/apps/chrome-extension/public/_locales/ko/messages.json
@@ -169,5 +169,9 @@
 	},
 	"summary_empty_message": {
 		"message": "위의 새로고침 버튼을 눌러\n요약을 생성해보세요"
-	}
+	},
+	"impression": { "message": "느낀 점" },
+	"impressionPlaceholder": { "message": "이 페이지에서 느낀 점을 적어보세요" },
+	"actionItem": { "message": "액션 아이템" },
+	"actionItemPlaceholder": { "message": "이 페이지를 보고 할 일을 적어보세요" }
 }

--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -42,6 +42,8 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 	const { register, watch, setValue } = useForm<MemoInput>({
 		defaultValues: {
 			memo: "",
+			impression: "",
+			actionItem: "",
 		},
 	});
 
@@ -54,22 +56,40 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 
 	const saveMemo = useCallback(() => {
 		const currentMemo = watch("memo");
-		const isEdited = currentMemo !== memoData?.memo;
+		const currentImpression = watch("impression");
+		const currentActionItem = watch("actionItem");
 
-		if (isEdited && currentMemo.trim() !== "") {
+		const isEdited =
+			currentMemo !== memoData?.memo ||
+			currentImpression !== (memoData?.impression ?? "") ||
+			currentActionItem !== (memoData?.actionItem ?? "");
+
+		if (isEdited) {
 			mutateMemoPatch({
 				id: memoId,
 				request: {
 					memo: currentMemo,
+					impression: currentImpression,
+					actionItem: currentActionItem,
 				},
 			});
 		}
-	}, [watch, memoData?.memo, mutateMemoPatch, memoId]);
+	}, [
+		watch,
+		memoData?.memo,
+		memoData?.impression,
+		memoData?.actionItem,
+		mutateMemoPatch,
+		memoId,
+	]);
 
 	useKeyboardBind({ key: "s", callback: saveMemo, isMetaKey: true });
 
 	const checkEditedAndCloseDialog = () => {
-		const isEdited = watch("memo") !== memoData?.memo;
+		const isEdited =
+			watch("memo") !== memoData?.memo ||
+			watch("impression") !== (memoData?.impression ?? "") ||
+			watch("actionItem") !== (memoData?.actionItem ?? "");
 
 		if (isEdited) setShowAlert(true);
 		else closeDialog();
@@ -92,6 +112,8 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 		function initMemoData() {
 			if (memoData) {
 				setValue("memo", memoData.memo);
+				setValue("impression", memoData.impression ?? "");
+				setValue("actionItem", memoData.actionItem ?? "");
 				if (textareaRef.current) {
 					adjustTextareaHeight(textareaRef.current);
 				}
@@ -104,7 +126,7 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 		function saveMemoOnChange() {
 			const subscription = watch((value) => {
 				debounce(() => {
-					if (!value.memo) return;
+					if (!value.memo && !value.impression && !value.actionItem) return;
 
 					saveMemo();
 				}, 1_000);
@@ -138,6 +160,34 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 									ref={textareaRef}
 									placeholder={t("memos.placeholder")}
 									data-testid="memo-textarea"
+								/>
+
+								<label
+									htmlFor="impression"
+									className="mt-3 text-xs font-semibold text-gray-500"
+								>
+									{t("memoSection.impression")}
+								</label>
+								<Textarea
+									id="impression"
+									className="outline-none focus:border-gray-300 focus:outline-none"
+									placeholder={t("memoSection.impressionPlaceholder")}
+									{...register("impression")}
+									data-testid="impression-textarea"
+								/>
+
+								<label
+									htmlFor="actionItem"
+									className="mt-3 text-xs font-semibold text-gray-500"
+								>
+									{t("memoSection.actionItem")}
+								</label>
+								<Textarea
+									id="actionItem"
+									className="outline-none focus:border-gray-300 focus:outline-none"
+									placeholder={t("memoSection.actionItemPlaceholder")}
+									{...register("actionItem")}
+									data-testid="action-item-textarea"
 								/>
 
 								<div className="h-4" />

--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoView/MemoItem.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoView/MemoItem.tsx
@@ -1,4 +1,5 @@
 import type { LanguageType } from "@src/modules/i18n";
+import useTranslation from "@src/modules/i18n/util.client";
 import { useSearchParams } from "@web-memo/shared/modules/search-params";
 import type { GetMemoResponse } from "@web-memo/shared/types";
 import { cn } from "@web-memo/shared/utils";
@@ -25,6 +26,7 @@ export default memo(function MemoItem({
 	isMemoSelected,
 	...props
 }: MemoItemProps) {
+	const { t } = useTranslation(lng);
 	const searchParams = useSearchParams();
 	const [isMemoHovering, setIsMemoHovering] = useState(false);
 
@@ -117,6 +119,18 @@ export default memo(function MemoItem({
 					{memo.memo && (
 						<CardContent className="px-5 py-3 text-gray-700 dark:text-gray-300 leading-relaxed whitespace-break-spaces break-all">
 							{memo.memo}
+						</CardContent>
+					)}
+					{memo.impression && (
+						<CardContent className="px-5 pb-3 text-gray-700 dark:text-gray-300 leading-relaxed whitespace-break-spaces break-all">
+							<p className="mb-1 text-xs font-semibold text-gray-400">{t("memoSection.impression")}</p>
+							{memo.impression}
+						</CardContent>
+					)}
+					{memo.actionItem && (
+						<CardContent className="px-5 pb-3 text-gray-700 dark:text-gray-300 leading-relaxed whitespace-break-spaces break-all">
+							<p className="mb-1 text-xs font-semibold text-gray-400">{t("memoSection.actionItem")}</p>
+							{memo.actionItem}
 						</CardContent>
 					)}
 					<MemoCardFooter

--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoView/MemoItem.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoView/MemoItem.tsx
@@ -123,13 +123,17 @@ export default memo(function MemoItem({
 					)}
 					{memo.impression && (
 						<CardContent className="px-5 pb-3 text-gray-700 dark:text-gray-300 leading-relaxed whitespace-break-spaces break-all">
-							<p className="mb-1 text-xs font-semibold text-gray-400">{t("memoSection.impression")}</p>
+							<p className="mb-1 text-xs font-semibold text-gray-400">
+								{t("memoSection.impression")}
+							</p>
 							{memo.impression}
 						</CardContent>
 					)}
 					{memo.actionItem && (
 						<CardContent className="px-5 pb-3 text-gray-700 dark:text-gray-300 leading-relaxed whitespace-break-spaces break-all">
-							<p className="mb-1 text-xs font-semibold text-gray-400">{t("memoSection.actionItem")}</p>
+							<p className="mb-1 text-xs font-semibold text-gray-400">
+								{t("memoSection.actionItem")}
+							</p>
 							{memo.actionItem}
 						</CardContent>
 					)}

--- a/apps/web/src/app/[lng]/(auth)/memos/_types/Input.ts
+++ b/apps/web/src/app/[lng]/(auth)/memos/_types/Input.ts
@@ -4,4 +4,6 @@ export interface CategoryInput {
 
 export type MemoInput = {
 	memo: string;
+	impression: string;
+	actionItem: string;
 };

--- a/apps/web/src/modules/i18n/locales/en/translation.json
+++ b/apps/web/src/modules/i18n/locales/en/translation.json
@@ -456,6 +456,14 @@
 		}
 	},
 
+	"memoSection": {
+		"memo": "Memo",
+		"impression": "Impression",
+		"impressionPlaceholder": "Write what you felt about this page",
+		"actionItem": "Action items",
+		"actionItemPlaceholder": "Write what to do after reading this page"
+	},
+
 	"memos": {
 		"emptyState": {
 			"title": "Create your first memo",

--- a/apps/web/src/modules/i18n/locales/ko/translation.json
+++ b/apps/web/src/modules/i18n/locales/ko/translation.json
@@ -451,6 +451,14 @@
 		}
 	},
 
+	"memoSection": {
+		"memo": "메모",
+		"impression": "느낀 점",
+		"impressionPlaceholder": "이 페이지에서 느낀 점을 적어보세요",
+		"actionItem": "액션 아이템",
+		"actionItemPlaceholder": "이 페이지를 보고 할 일을 적어보세요"
+	},
+
 	"memos": {
 		"emptyState": {
 			"title": "첫 메모를 작성해보세요",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -125,6 +125,7 @@
 		"@web-memo/env": "workspace:*",
 		"@web-memo/tsconfig": "workspace:*",
 		"@types/chrome": "^0.0.268",
-		"@types/react": "^19.1.0"
+		"@types/react": "^19.1.0",
+		"vitest": "^2.1.5"
 	}
 }

--- a/packages/shared/src/hooks/supabase/mutations/useMemoUpsertMutation.ts
+++ b/packages/shared/src/hooks/supabase/mutations/useMemoUpsertMutation.ts
@@ -74,17 +74,19 @@ export default function useMemoUpsertMutation() {
 						updated_at: new Date().toISOString(),
 					} as MemoRow)
 				: {
-						id: -Date.now(),
-						user_id: "",
-						url: data.url ?? "",
-						title: data.title ?? "",
-						memo: data.memo ?? "",
-						favIconUrl: data.favIconUrl ?? null,
-						isWish: data.isWish ?? false,
-						isStar: data.isStar ?? false,
+						actionItem: data.actionItem ?? null,
 						category_id: data.category_id ?? null,
 						created_at: new Date().toISOString(),
+						favIconUrl: data.favIconUrl ?? null,
+						id: -Date.now(),
+						impression: data.impression ?? null,
+						isStar: data.isStar ?? false,
+						isWish: data.isWish ?? false,
+						memo: data.memo ?? "",
+						title: data.title ?? "",
 						updated_at: new Date().toISOString(),
+						url: data.url ?? "",
+						user_id: "",
 					};
 
 			queryClient.setQueryData(QUERY_KEY.memo({ url: normalizedUrl }), {

--- a/packages/shared/src/types/supabase.ts
+++ b/packages/shared/src/types/supabase.ts
@@ -75,10 +75,12 @@ export type Database = {
 			};
 			memo: {
 				Row: {
+					actionItem: string | null;
 					category_id: number | null;
 					created_at: string | null;
 					favIconUrl: string | null;
 					id: number;
+					impression: string | null;
 					isStar: boolean | null;
 					isWish: boolean | null;
 					memo: string;
@@ -88,10 +90,12 @@ export type Database = {
 					user_id: string;
 				};
 				Insert: {
+					actionItem?: string | null;
 					category_id?: number | null;
 					created_at?: string | null;
 					favIconUrl?: string | null;
 					id?: number;
+					impression?: string | null;
 					isStar?: boolean | null;
 					isWish?: boolean | null;
 					memo: string;
@@ -101,10 +105,12 @@ export type Database = {
 					user_id?: string;
 				};
 				Update: {
+					actionItem?: string | null;
 					category_id?: number | null;
 					created_at?: string | null;
 					favIconUrl?: string | null;
 					id?: number;
+					impression?: string | null;
 					isStar?: boolean | null;
 					isWish?: boolean | null;
 					memo?: string;

--- a/packages/shared/src/utils/Supabase.ts
+++ b/packages/shared/src/utils/Supabase.ts
@@ -9,6 +9,7 @@ import type {
 	MemoSupabaseClient,
 	MemoTable,
 } from "../types";
+import { getMemoSearchFilter } from "./memoSearchFilter";
 
 export class MemoService {
 	supabaseClient: MemoSupabaseClient;
@@ -136,8 +137,7 @@ export class MemoService {
 		}
 
 		if (searchQuery) {
-			const pattern = `%${searchQuery}%`;
-			query = query.or(`title.ilike.${pattern},memo.ilike.${pattern}`);
+			query = query.or(getMemoSearchFilter(searchQuery));
 		}
 
 		return query;

--- a/packages/shared/src/utils/memoSearchFilter.test.ts
+++ b/packages/shared/src/utils/memoSearchFilter.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { getMemoSearchFilter } from "./memoSearchFilter";
+
+describe("getMemoSearchFilter", () => {
+	it("title/memo/impression/actionItem 네 컬럼에 대한 ilike OR 필터 문자열을 만든다", () => {
+		expect(getMemoSearchFilter("hello")).toBe(
+			"title.ilike.%hello%,memo.ilike.%hello%,impression.ilike.%hello%,actionItem.ilike.%hello%",
+		);
+	});
+});

--- a/packages/shared/src/utils/memoSearchFilter.ts
+++ b/packages/shared/src/utils/memoSearchFilter.ts
@@ -1,0 +1,14 @@
+/**
+ * 메모 검색(searchQuery)을 Supabase `.or()` 필터 문자열로 변환한다.
+ * title, memo, impression, actionItem 네 컬럼을 부분 일치(ilike)로 검색한다.
+ */
+export function getMemoSearchFilter(searchQuery: string): string {
+	const pattern = `%${searchQuery}%`;
+
+	return [
+		`title.ilike.${pattern}`,
+		`memo.ilike.${pattern}`,
+		`impression.ilike.${pattern}`,
+		`actionItem.ilike.${pattern}`,
+	].join(",");
+}

--- a/packages/supabase-edge-functions/supabase/migrations/20260622_add_note_sections_to_memo.sql
+++ b/packages/supabase-edge-functions/supabase/migrations/20260622_add_note_sections_to_memo.sql
@@ -1,0 +1,6 @@
+-- 메모에 "느낀 점(impression)"과 "액션 아이템(actionItem)" 섹션 텍스트 컬럼 추가.
+-- 기존 자유 텍스트 memo 컬럼과 독립된 고정 섹션. 둘 다 nullable.
+ALTER TABLE memo.memo
+  ADD COLUMN IF NOT EXISTS "impression" text;
+ALTER TABLE memo.memo
+  ADD COLUMN IF NOT EXISTS "actionItem" text;

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
@@ -15,8 +15,6 @@ import { useFormContext } from "react-hook-form";
 interface SaveMemoOptions extends Partial<MemoInput> {
 	tabInfo?: { title: string; favIconUrl?: string; url: string };
 	memoId?: number;
-	impression?: string;
-	actionItem?: string;
 }
 
 interface UseMemoFormProps {

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/hooks/useMemoForm.ts
@@ -15,6 +15,8 @@ import { useFormContext } from "react-hook-form";
 interface SaveMemoOptions extends Partial<MemoInput> {
 	tabInfo?: { title: string; favIconUrl?: string; url: string };
 	memoId?: number;
+	impression?: string;
+	actionItem?: string;
 }
 
 interface UseMemoFormProps {
@@ -46,6 +48,8 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 
 			if (isNewMemo) {
 				setValue("memo", memoData?.memo ?? "");
+				setValue("impression", memoData?.impression ?? "");
+				setValue("actionItem", memoData?.actionItem ?? "");
 				initializedMemoIdRef.current = currentMemoId;
 			}
 
@@ -56,6 +60,8 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 		[
 			memoData?.id,
 			memoData?.memo,
+			memoData?.impression,
+			memoData?.actionItem,
 			memoData?.isWish,
 			memoData?.isStar,
 			memoData?.category_id,
@@ -73,6 +79,8 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 			const currentValues = getValues();
 			const memoInput: MemoInput = {
 				memo: overrides?.memo ?? currentValues.memo,
+				impression: overrides?.impression ?? currentValues.impression,
+				actionItem: overrides?.actionItem ?? currentValues.actionItem,
 				isWish: overrides?.isWish ?? currentValues.isWish,
 				isStar: overrides?.isStar ?? currentValues.isStar,
 				categoryId: overrides?.categoryId ?? currentValues.categoryId,
@@ -91,6 +99,8 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 					data: {
 						...tabInfo,
 						memo: memoInput.memo,
+						impression: memoInput.impression,
+						actionItem: memoInput.actionItem,
 						isWish: memoInput.isWish,
 						isStar: memoInput.isStar,
 						category_id: memoInput.categoryId,
@@ -126,6 +136,22 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 		[setValue, debounce, saveMemo],
 	);
 
+	const handleImpressionChange = useCallback(
+		(text: string) => {
+			setValue("impression", text);
+			debounce(() => saveMemo({ impression: text }));
+		},
+		[setValue, debounce, saveMemo],
+	);
+
+	const handleActionItemChange = useCallback(
+		(text: string) => {
+			setValue("actionItem", text);
+			debounce(() => saveMemo({ actionItem: text }));
+		},
+		[setValue, debounce, saveMemo],
+	);
+
 	const updateCategory = useCallback(
 		(categoryId: number | null) => {
 			setValue("categoryId", categoryId);
@@ -157,6 +183,8 @@ export default function useMemoForm({ onSaveSuccess }: UseMemoFormProps = {}) {
 		isSaving,
 		saveMemo,
 		handleMemoChange,
+		handleImpressionChange,
+		handleActionItemChange,
 		updateCategory,
 		toggleWish,
 		toggleStar,

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
@@ -140,7 +140,10 @@ function MemoFormContent() {
 						textareaRef.current = e;
 					}}
 				/>
-				<label htmlFor="impression-textarea" className="mt-3 text-xs font-semibold text-gray-500">
+				<label
+					htmlFor="impression-textarea"
+					className="mt-3 text-xs font-semibold text-gray-500"
+				>
 					{I18n.get("impression")}
 				</label>
 				<Textarea
@@ -151,7 +154,10 @@ function MemoFormContent() {
 						onChange: (event) => handleImpressionChange(event.target.value),
 					})}
 				/>
-				<label htmlFor="action-item-textarea" className="mt-3 text-xs font-semibold text-gray-500">
+				<label
+					htmlFor="action-item-textarea"
+					className="mt-3 text-xs font-semibold text-gray-500"
+				>
 					{I18n.get("actionItem")}
 				</label>
 				<Textarea

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
@@ -32,6 +32,8 @@ function MemoFormContent() {
 		memoData,
 		isSaving,
 		handleMemoChange,
+		handleImpressionChange,
+		handleActionItemChange,
 		updateCategory,
 		toggleWish,
 		toggleStar,
@@ -137,6 +139,28 @@ function MemoFormContent() {
 						ref(e);
 						textareaRef.current = e;
 					}}
+				/>
+				<label htmlFor="impression-textarea" className="mt-3 text-xs font-semibold text-gray-500">
+					{I18n.get("impression")}
+				</label>
+				<Textarea
+					id="impression-textarea"
+					className="resize-none text-sm outline-none"
+					placeholder={I18n.get("impressionPlaceholder")}
+					{...register("impression", {
+						onChange: (event) => handleImpressionChange(event.target.value),
+					})}
+				/>
+				<label htmlFor="action-item-textarea" className="mt-3 text-xs font-semibold text-gray-500">
+					{I18n.get("actionItem")}
+				</label>
+				<Textarea
+					id="action-item-textarea"
+					className="resize-none text-sm outline-none"
+					placeholder={I18n.get("actionItemPlaceholder")}
+					{...register("actionItem", {
+						onChange: (event) => handleActionItemChange(event.target.value),
+					})}
 				/>
 				<div className="flex items-center justify-between gap-2">
 					<div className="flex items-center gap-2">
@@ -245,6 +269,8 @@ function MemoForm() {
 	const form = useForm<MemoInput>({
 		defaultValues: {
 			memo: "",
+			impression: "",
+			actionItem: "",
 			isWish: false,
 			isStar: false,
 			categoryId: null,

--- a/pages/side-panel/src/types/Input.ts
+++ b/pages/side-panel/src/types/Input.ts
@@ -1,5 +1,7 @@
 export interface MemoInput {
 	memo: string;
+	impression: string;
+	actionItem: string;
 	isWish: boolean;
 	isStar: boolean;
 	categoryId: number | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,7 +208,7 @@ importers:
         version: link:../../packages/env
       babel-preset-expo:
         specifier: ^54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33)(react-refresh@0.14.2)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33)(react-refresh@0.17.0)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -260,7 +260,7 @@ importers:
         version: 0.30.21
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.4(typescript@5.9.3)(webpack@5.105.2)
+        version: 9.5.4(typescript@5.5.3)(webpack@5.105.2)
       vite:
         specifier: 5.3.3
         version: 5.3.3(@types/node@24.10.13)(lightningcss@1.31.1)(terser@5.46.0)
@@ -470,7 +470,7 @@ importers:
         version: 4.57.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3)
       vite:
         specifier: 5.3.3
         version: 5.3.3(@types/node@24.10.13)(lightningcss@1.31.1)(terser@5.46.0)
@@ -523,19 +523,22 @@ importers:
       '@web-memo/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@24.10.13)(lightningcss@1.31.1)(terser@5.46.0)
 
   packages/tailwind-config:
     dependencies:
       tailwindcss:
         specifier: ^3.4.10
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
+        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3))
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.14
-        version: 0.5.19(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))
+        version: 0.5.19(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3)))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3)))
 
   packages/tsconfig: {}
 
@@ -709,10 +712,10 @@ importers:
         version: 8.5.6
       tailwindcss:
         specifier: ^3.4.10
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
+        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3)))
 
   packages/vite-config:
     dependencies:
@@ -877,7 +880,7 @@ importers:
         version: 7.0.3
       tailwindcss:
         specifier: ^3.4.10
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
+        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3))
       vite:
         specifier: 5.3.3
         version: 5.3.3(@types/node@24.10.13)(lightningcss@1.31.1)(terser@5.46.0)
@@ -950,7 +953,7 @@ importers:
         version: 6.0.5(rollup@4.57.1)
       tailwindcss:
         specifier: ^3.4.10
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
+        version: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3))
       vite:
         specifier: 5.3.3
         version: 5.3.3(@types/node@24.10.13)(lightningcss@1.31.1)(terser@5.46.0)
@@ -4206,6 +4209,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upstash/core-analytics@0.0.10':
     resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
@@ -4315,6 +4319,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5726,6 +5731,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -7459,6 +7465,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -7925,6 +7932,7 @@ packages:
   syncpack@14.0.0:
     resolution: {integrity: sha512-OfAa3Oip5YC9Ad1jEs92Hw08Wy4JfdpdeequIwaJGsQG0tJtb8gpQfCdLuBefsk6n8WiUdt/5qmzcW+BDXtzbQ==}
     engines: {node: '>=14.17.0'}
+    deprecated: 'pnpm users: upgrade to 14.0.2 or newer'
     hasBin: true
 
   tailwind-merge@2.6.1:
@@ -8301,10 +8309,12 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -12684,6 +12694,38 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33)(react-refresh@0.17.0):
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/babel-preset': 0.81.5(@babel/core@7.29.0)
+      babel-plugin-react-compiler: 1.0.0
+      babel-plugin-react-native-web: 0.21.2
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      debug: 4.4.3
+      react-refresh: 0.17.0
+      resolve-from: 5.0.0
+    optionalDependencies:
+      '@babel/runtime': 7.28.6
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   babel-preset-jest@29.6.3(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -16453,10 +16495,6 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3))
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))):
-    dependencies:
-      tailwindcss: 3.4.10(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
-
   tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -16653,14 +16691,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.5.4(typescript@5.9.3)(webpack@5.105.2):
+  ts-loader@9.5.4(typescript@5.5.3)(webpack@5.105.2):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.19.0
       micromatch: 4.0.8
       semver: 7.7.4
       source-map: 0.7.6
-      typescript: 5.9.3
+      typescript: 5.5.3
       webpack: 5.105.2
 
   ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.5.3):
@@ -16682,7 +16720,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.11
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.10.13)(typescript@5.9.3):
     dependencies:
@@ -16703,6 +16740,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.11
+    optional: true
 
   tsc-watch@6.3.1(typescript@5.5.3):
     dependencies:


### PR DESCRIPTION
## 작업 내용
저장한 페이지(메모 레코드) 하나에 **메모 / 느낀 점 / 액션 아이템** 3개 고정 자유 텍스트 섹션을 작성·조회할 수 있게 했습니다. 기존에는 자유 텍스트 `memo` 한 칸만 작성 가능했습니다.

익스텐션·웹·앱 전부에 적용되며, 기존 메모(두 섹션 비어 있음)는 그대로 동작합니다(하위호환).

## 변경 사항
**데이터 모델**
- `memo` 테이블에 `impression`(느낀 점), `actionItem`(액션 아이템) nullable 텍스트 컬럼 추가 (마이그레이션 `20260622_add_note_sections_to_memo.sql`)
- Supabase 타입 갱신

**공유 계층 (`packages/shared`)**
- 메모 검색(`getMemoSearchFilter`)에 두 컬럼 포함 (title/memo/impression/actionItem 4컬럼)
- 옵티미스틱 업데이트에 두 필드 반영

**작성 UI**
- 익스텐션 사이드패널 `MemoForm` — 두 섹션 Textarea + 자동저장
- 웹 `MemoDialog` — 두 섹션 Textarea + 자동저장(세 섹션 중 하나라도 있으면 저장)
- 앱 `MemoPanel` — 두 섹션 TextInput + 로컬/Supabase 저장

**표시 UI** (채워진 섹션만 라벨과 함께 노출)
- 웹 `MemoItem`, 앱 `MemoCard`·`MemoDetailModal`

**데이터 유실 방지**
- 위시 취소 시 빈 메모 삭제 판정에 두 섹션 포함(채워진 메모 삭제 금지)
- 앱 로컬→Supabase 동기화·삭제취소(undo)·로컬 upsert에서 두 필드 유실 방지

**i18n**
- 웹 `translation.json`(ko/en), 익스텐션 `messages.json`(ko/en) 섹션 라벨 추가

## 테스트
- [x] `pnpm type-check` 통과 (14/14)
- [x] `pnpm lint` 0 errors
- [x] 단위 테스트 `getMemoSearchFilter` 통과
- [x] i18n 키 ko/en 대칭 확인(웹·익스텐션)
- [ ] **수동 통합 검증 필요** (아래)

## 수동 검증 체크리스트
- [ ] 익스텐션에서 메모/느낀 점/액션 아이템 입력 → 자동 저장
- [ ] 웹 목록에서 같은 메모에 세 섹션 표시·편집·저장
- [ ] 앱 브라우저 패널에서 세 섹션 로드·저장, 카드/상세에 채워진 섹션만 표시
- [ ] 기존(섹션 미입력) 메모 정상 표시·편집(하위호환)
- [ ] 메모 본문 비우고 느낀 점만 있는 페이지의 위시 취소 시 레코드 미삭제

## ⚠️ 배포 전 필수
- 마이그레이션 `20260622_add_note_sections_to_memo.sql`을 **Supabase에 적용**해야 기능이 동작합니다(이 PR에는 SQL 파일만 포함, 라이브 DB 미적용).
