### PR TITLE
docs: 브랜치 전략을 master 단일 기준으로 변경

### DIFF
--- a/.claude/commands/version-update.md
+++ b/.claude/commands/version-update.md
@@ -15,7 +15,7 @@
 
 ## 실행 절차
 
-### 0단계: 브랜치 확인 및 머지
+### 0단계: 브랜치 확인
 
 먼저 현재 브랜치를 확인하고 master 브랜치로 이동합니다:
 
@@ -24,12 +24,11 @@ git branch --show-current
 ```
 
 **master 브랜치가 아닌 경우:**
-1. master 브랜치로 이동
-2. develop 브랜치를 master로 머지
+1. master 브랜치로 이동 후 최신화
 
 ```bash
 git checkout master
-git merge develop
+git pull
 ```
 
 ### 1단계: 변경 내용 분석

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,7 +32,7 @@ reviews:
     ignore_title_keywords: []
     labels: []
     drafts: false
-    base_branches: ['master', 'develop']
+    base_branches: ['master']
   tools:
     shellcheck:
       enabled: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,8 +367,9 @@ claudedocs/
 
 1. 작업 완료
 2. `pnpm type-check` 및 `pnpm lint`로 검증
-3. develop 브랜치에서 새 브랜치 생성(이미 feature 브랜치면 생략)
-4. 의미 있는 단위로 커밋 → 원격 푸시 → PR 생성
+3. master 브랜치에서 새 브랜치 생성(이미 feature 브랜치면 생략)
+4. 의미 있는 단위로 커밋 → 원격 푸시 → master를 대상(base)으로 PR 생성
+5. 머지는 **Squash & Merge가 아니라 머지 커밋 생성** 방식으로 진행
 
 ### 언어 규칙 (MANDATORY)
 
@@ -376,6 +377,12 @@ claudedocs/
 - **PR 제목**: 한글 (예: `feat: 메모 검색 기능 구현`)
 - **PR 본문**: 요약/변경사항/테스트 계획 모두 한글
 - **브랜치명**: 영문 유지 (예: `feat/memo-search`, `fix/login-error`)
+
+### 브랜치 규칙 (MANDATORY)
+
+- 모든 브랜치는 **`master`에서 분기**한다.
+- 모든 PR의 base(target) 브랜치는 **`master`**다.
+- 머지는 **Squash & Merge를 쓰지 않고 머지 커밋을 생성**해 진행한다. (개별 커밋 히스토리 보존)
 
 ### 세부 컨벤션 문서
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 3. `/pr` 명령어로 PR 생성
 
 `/pr` 명령어는 다음을 수행합니다:
-- develop 브랜치에서 새 브랜치 생성(이미 feature 브랜치면 생략)
+- master 브랜치에서 새 브랜치 생성(이미 feature 브랜치면 생략)
 - 변경사항을 의미 있는 커밋 메시지로 커밋
-- 원격 푸시 후 PR 생성
+- 원격 푸시 후 master를 대상(base)으로 PR 생성 (머지는 Squash가 아닌 머지 커밋 방식)
 
 커밋/PR 제목·본문은 **항상 한글**, 브랜치명은 영문입니다. 자세한 규칙은 [AGENTS.md](AGENTS.md)의 "커밋 & PR 워크플로" 절을 따릅니다.
 

--- a/docs/branch-strategy.md
+++ b/docs/branch-strategy.md
@@ -2,52 +2,36 @@
 
 This document outlines our Git branch strategy and merging conventions.
 
-## Main Branches
+## Main Branch
 
 ### `master`
 - Production-ready branch that users can rely on
 - Contains stable, tested code
-- Base branch for `develop`
+- The single base branch: all branches are created from `master`, and all work is merged back into `master`
 
-### `develop`
-- Main development branch
+### `feature/*` (and `fix/*`, etc.)
+- Feature/bugfix development branches
 - Branched from `master`
-- When merging to `master`, use **recursive merge**
-  - This preserves the commit history in `master`
+- Merged back into `master` via a Pull Request targeting `master`
+- When merging, use a **merge commit** (do **NOT** use Squash & Merge)
+  - This preserves the individual commit history in `master`
   - Makes it easier to track feature additions in the commit history
+- Naming convention: `feature/feature-name`, `fix/bug-name`
 
-### `feature/*`
-- Feature development branches
-- Branched from `develop`
-- When merging to `develop`, use **Squash & Merge**
-- Naming convention: `feature/feature-name`
+## Pull Request & Merging Conventions
 
-## Merging Conventions
+- **Base branch (target)**: always `master`
+- **Merge method**: **Create a merge commit** — never Squash & Merge, never Rebase & Merge
 
-### feature/* → develop
 ```bash
-# When merging a feature branch to develop
-git checkout develop
-git merge --squash feature/xx-yy-zz
-git commit -m "feat: Add xx-yy-zz feature"
-```
-
-### develop → master
-```bash
-# When merging develop to master
+# Create a feature branch from master
 git checkout master
-git merge develop
+git pull
+git checkout -b feature/xx-yy-zz
+
+# ...work, commit...
+
+# Open a PR targeting master, then merge with a merge commit
+gh pr create --base master
+gh pr merge --merge
 ```
-
-## Special Cases
-
-### Hotfix Synchronization
-When `master` receives hotfixes or critical updates that need to be synchronized with `develop`:
-1. Apply the hotfix to `master`
-2. Merge `master` into `develop` using a regular merge
-```bash
-git checkout develop
-git merge master
-```
-
-This ensures that `develop` stays up-to-date with any critical fixes in `master` while maintaining the commit history.


### PR DESCRIPTION
## 변경 요약

git 브랜치 전략을 `develop` 폐지 후 `master` 단일 기준으로 변경합니다.

## 주요 변경점

- 모든 브랜치를 `master`에서 분기하고 `master`를 대상(base)으로 PR/머지하도록 변경
- 머지 방식을 Squash & Merge → **머지 커밋 생성**으로 변경 (개별 커밋 히스토리 보존)
- `develop` 브랜치 폐지에 따라 `version-update` 커맨드·`.coderabbit.yaml` 설정 정리
