### PR TITLE
feat: 앱 메모 패널 헤더 고정 + 메모 상세 바텀시트 수정 기능

### DIFF
--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -1,7 +1,10 @@
 import {
+	Check,
 	FileText,
 	Globe,
 	HeartOff,
+	Pencil,
+	Save,
 	Share2,
 	Star,
 	StarOff,
@@ -11,10 +14,14 @@ import { useCallback, useEffect, useState } from "react";
 import {
 	Dimensions,
 	Image,
+	Keyboard,
+	KeyboardAvoidingView,
 	Modal,
+	Platform,
 	Pressable,
 	ScrollView,
 	Text,
+	TextInput,
 	TouchableOpacity,
 	View,
 } from "react-native";
@@ -38,6 +45,10 @@ interface MemoDetailModalProps {
 	onNavigate: (url: string) => void;
 	onWishRemove?: (memo: MemoItem) => void;
 	onStarToggle?: (memo: MemoItem) => void;
+	onSave?: (
+		memo: MemoItem,
+		next: { memo: string; impression: string; actionItem: string },
+	) => void;
 }
 
 export function MemoDetailModal({
@@ -46,11 +57,17 @@ export function MemoDetailModal({
 	onNavigate,
 	onWishRemove,
 	onStarToggle,
+	onSave,
 }: MemoDetailModalProps) {
 	const insets = useSafeAreaInsets();
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
+	const [isEditing, setIsEditing] = useState(false);
+	const [editedMemo, setEditedMemo] = useState("");
+	const [editedImpression, setEditedImpression] = useState("");
+	const [editedActionItem, setEditedActionItem] = useState("");
+	const [saved, setSaved] = useState(false);
 
 	const visible = memo !== null;
 
@@ -66,6 +83,19 @@ export function MemoDetailModal({
 			return () => clearTimeout(timer);
 		}
 	}, [visible, translateY, opacity]);
+
+	useEffect(
+		function syncEditState() {
+			if (memo) {
+				setEditedMemo(memo.memo ?? "");
+				setEditedImpression(memo.impression ?? "");
+				setEditedActionItem(memo.actionItem ?? "");
+				setIsEditing(false);
+				setSaved(false);
+			}
+		},
+		[memo],
+	);
 
 	const sheetStyle = useAnimatedStyle(() => ({
 		transform: [{ translateY: translateY.value }],
@@ -101,6 +131,43 @@ export function MemoDetailModal({
 
 	const title = memo?.title || "Untitled";
 	const memoText = memo?.memo ?? "";
+	const impressionText = memo?.impression ?? "";
+	const actionItemText = memo?.actionItem ?? "";
+
+	const handleStartEdit = () => {
+		setEditedMemo(memoText);
+		setEditedImpression(impressionText);
+		setEditedActionItem(actionItemText);
+		setIsEditing(true);
+	};
+
+	const handleCancelEdit = () => {
+		setEditedMemo(memoText);
+		setEditedImpression(impressionText);
+		setEditedActionItem(actionItemText);
+		setIsEditing(false);
+		Keyboard.dismiss();
+	};
+
+	const handleSaveMemo = () => {
+		if (!memo) return;
+
+		onSave?.(memo, {
+			memo: editedMemo.trim(),
+			impression: editedImpression.trim(),
+			actionItem: editedActionItem.trim(),
+		});
+		setIsEditing(false);
+		setSaved(true);
+		Keyboard.dismiss();
+		setTimeout(() => setSaved(false), 2000);
+	};
+
+	const isMemoEdited =
+		editedMemo.trim() !== memoText.trim() ||
+		editedImpression.trim() !== impressionText.trim() ||
+		editedActionItem.trim() !== actionItemText.trim();
+
 	const favIconUrl = memo && "favIconUrl" in memo ? memo.favIconUrl : undefined;
 	const isWish = memo && "isWish" in memo ? memo.isWish : false;
 	const isStar = memo && "isStar" in memo ? memo.isStar : false;
@@ -116,7 +183,10 @@ export function MemoDetailModal({
 
 	return (
 		<Modal visible={modalVisible} transparent statusBarTranslucent>
-			<View className="flex-1 justify-end">
+			<KeyboardAvoidingView
+				className="flex-1 justify-end"
+				behavior={Platform.OS === "ios" ? "padding" : undefined}
+			>
 				<Animated.View
 					className="absolute inset-0 bg-black/40"
 					style={overlayStyle}
@@ -167,59 +237,156 @@ export function MemoDetailModal({
 								</Text>
 							</View>
 						)}
-						{onStarToggle && (
-							<TouchableOpacity onPress={handleStarToggle} activeOpacity={0.7}>
-								{isStar ? (
-									<StarOff size={20} color="#f59e0b" />
-								) : (
-									<Star size={20} color="#f59e0b" fill="#f59e0b" />
+						{isEditing ? (
+							<>
+								<TouchableOpacity
+									className="px-2 py-1"
+									onPress={handleCancelEdit}
+									activeOpacity={0.7}
+								>
+									<Text className="text-sm font-medium text-muted-foreground">
+										취소
+									</Text>
+								</TouchableOpacity>
+								<TouchableOpacity
+									className={`flex-row items-center gap-1 px-3 py-1.5 rounded-lg ${isMemoEdited ? "bg-foreground" : "bg-muted"}`}
+									onPress={handleSaveMemo}
+									disabled={!isMemoEdited}
+									activeOpacity={0.7}
+								>
+									<Save size={14} color={isMemoEdited ? "#fff" : "#999"} />
+									<Text
+										className={`text-sm font-semibold ${isMemoEdited ? "text-white" : "text-gray-400"}`}
+									>
+										저장
+									</Text>
+								</TouchableOpacity>
+							</>
+						) : (
+							<>
+								{onSave ? (
+									<TouchableOpacity
+										onPress={handleStartEdit}
+										activeOpacity={0.7}
+									>
+										{saved ? (
+											<Check size={20} color="#22c55e" />
+										) : (
+											<Pencil size={18} color="#666" />
+										)}
+									</TouchableOpacity>
+								) : null}
+								{onStarToggle && (
+									<TouchableOpacity
+										onPress={handleStarToggle}
+										activeOpacity={0.7}
+									>
+										{isStar ? (
+											<StarOff size={20} color="#f59e0b" />
+										) : (
+											<Star size={20} color="#f59e0b" fill="#f59e0b" />
+										)}
+									</TouchableOpacity>
 								)}
-							</TouchableOpacity>
+								{isWish && (
+									<TouchableOpacity
+										onPress={handleWishRemove}
+										activeOpacity={0.7}
+									>
+										<HeartOff size={20} color="#ec4899" />
+									</TouchableOpacity>
+								)}
+								{isWebUrl && (
+									<TouchableOpacity onPress={handleShare} activeOpacity={0.7}>
+										<Share2 size={20} color="#666" />
+									</TouchableOpacity>
+								)}
+								<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
+									<X size={22} color="#666" />
+								</TouchableOpacity>
+							</>
 						)}
-						{isWish && (
-							<TouchableOpacity onPress={handleWishRemove} activeOpacity={0.7}>
-								<HeartOff size={20} color="#ec4899" />
-							</TouchableOpacity>
-						)}
-						{isWebUrl && (
-							<TouchableOpacity onPress={handleShare} activeOpacity={0.7}>
-								<Share2 size={20} color="#666" />
-							</TouchableOpacity>
-						)}
-						<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
-							<X size={22} color="#666" />
-						</TouchableOpacity>
 					</View>
 
-					<ScrollView
-						className="flex-1 px-5"
-						contentContainerStyle={{ paddingBottom: 12 }}
-						showsVerticalScrollIndicator={false}
-					>
-						<Text className="text-[15px] text-[#333] leading-[22px]">
-							{memoText}
-						</Text>
-						{memo?.impression ? (
-							<View className="mt-3">
-								<Text className="text-xs font-semibold text-gray-500 mb-1">
-									느낀 점
-								</Text>
+					{isEditing ? (
+						<ScrollView
+							className="flex-1 px-5"
+							contentContainerStyle={{ paddingBottom: 12 }}
+							keyboardShouldPersistTaps="handled"
+							showsVerticalScrollIndicator={false}
+						>
+							<TextInput
+								className="min-h-[80px] text-[15px] text-[#333] leading-[22px]"
+								value={editedMemo}
+								onChangeText={setEditedMemo}
+								placeholder="메모를 입력하세요..."
+								multiline
+								textAlignVertical="top"
+								scrollEnabled={false}
+								autoFocus
+							/>
+							<Text className="mt-3 text-xs font-semibold text-gray-500">
+								느낀 점
+							</Text>
+							<TextInput
+								className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
+								value={editedImpression}
+								onChangeText={setEditedImpression}
+								placeholder="이 페이지에서 느낀 점을 적어보세요"
+								multiline
+								textAlignVertical="top"
+								scrollEnabled={false}
+							/>
+							<Text className="mt-3 text-xs font-semibold text-gray-500">
+								액션 아이템
+							</Text>
+							<TextInput
+								className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
+								value={editedActionItem}
+								onChangeText={setEditedActionItem}
+								placeholder="이 페이지를 보고 할 일을 적어보세요"
+								multiline
+								textAlignVertical="top"
+								scrollEnabled={false}
+							/>
+						</ScrollView>
+					) : (
+						<ScrollView
+							className="flex-1 px-5"
+							contentContainerStyle={{ paddingBottom: 12 }}
+							showsVerticalScrollIndicator={false}
+						>
+							{memoText ? (
 								<Text className="text-[15px] text-[#333] leading-[22px]">
-									{memo.impression}
+									{memoText}
 								</Text>
-							</View>
-						) : null}
-						{memo?.actionItem ? (
-							<View className="mt-3">
-								<Text className="text-xs font-semibold text-gray-500 mb-1">
-									액션 아이템
+							) : (
+								<Text className="text-[15px] text-gray-400 leading-[22px]">
+									메모가 없습니다. 연필 아이콘을 눌러 작성하세요.
 								</Text>
-								<Text className="text-[15px] text-[#333] leading-[22px]">
-									{memo.actionItem}
-								</Text>
-							</View>
-						) : null}
-					</ScrollView>
+							)}
+							{memo?.impression ? (
+								<View className="mt-3">
+									<Text className="text-xs font-semibold text-gray-500 mb-1">
+										느낀 점
+									</Text>
+									<Text className="text-[15px] text-[#333] leading-[22px]">
+										{memo.impression}
+									</Text>
+								</View>
+							) : null}
+							{memo?.actionItem ? (
+								<View className="mt-3">
+									<Text className="text-xs font-semibold text-gray-500 mb-1">
+										액션 아이템
+									</Text>
+									<Text className="text-[15px] text-[#333] leading-[22px]">
+										{memo.actionItem}
+									</Text>
+								</View>
+							) : null}
+						</ScrollView>
+					)}
 
 					<View className="flex-row items-center justify-between px-5 pt-2 pb-1">
 						<View className="flex-row items-center gap-2">
@@ -239,7 +406,7 @@ export function MemoDetailModal({
 						</View>
 					</View>
 				</Animated.View>
-			</View>
+			</KeyboardAvoidingView>
 		</Modal>
 	);
 }

--- a/apps/app/app/(main)/_hooks/useMemoList.ts
+++ b/apps/app/app/(main)/_hooks/useMemoList.ts
@@ -3,10 +3,12 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 import {
 	useLocalMemoStarToggle,
 	useLocalMemos,
+	useLocalMemoUpsert,
 	useLocalMemoWishToggle,
 } from "@/lib/hooks/useLocalMemos";
 import {
 	useMemoStarToggleMutation,
+	useMemoUpsertMutation,
 	useMemoWishToggleMutation,
 } from "@/lib/hooks/useMemoMutation";
 import { useMemosInfinite } from "@/lib/hooks/useMemos";
@@ -22,6 +24,8 @@ export function useMemoList() {
 	const wishToggleSupabase = useMemoWishToggleMutation();
 	const starToggleLocal = useLocalMemoStarToggle();
 	const starToggleSupabase = useMemoStarToggleMutation();
+	const upsertLocal = useLocalMemoUpsert();
+	const upsertSupabase = useMemoUpsertMutation();
 
 	const {
 		data: localMemosData,
@@ -92,6 +96,33 @@ export function useMemoList() {
 		}
 	};
 
+	const handleMemoSave = (
+		memo: MemoItem,
+		next: { memo: string; impression: string; actionItem: string },
+	) => {
+		const favIconUrl =
+			"favIconUrl" in memo ? (memo.favIconUrl ?? undefined) : undefined;
+		if (isLoggedIn) {
+			upsertSupabase.mutate({
+				url: memo.url,
+				title: memo.title,
+				memo: next.memo,
+				impression: next.impression,
+				actionItem: next.actionItem,
+				favIconUrl,
+			});
+		} else {
+			upsertLocal.mutate({
+				url: memo.url,
+				title: memo.title,
+				memo: next.memo,
+				impression: next.impression,
+				actionItem: next.actionItem,
+				favIconUrl,
+			});
+		}
+	};
+
 	return {
 		isLoggedIn,
 		filter,
@@ -103,5 +134,6 @@ export function useMemoList() {
 		handleEndReached,
 		handleWishRemove,
 		handleStarToggle,
+		handleMemoSave,
 	};
 }

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -141,13 +141,7 @@ export function MemoPanel({
 	};
 
 	return (
-		<ScrollView
-			className="flex-1 bg-white p-3"
-			keyboardShouldPersistTaps="handled"
-			keyboardDismissMode="interactive"
-			contentContainerStyle={{ flexGrow: 1, paddingBottom: 24 }}
-			showsVerticalScrollIndicator={false}
-		>
+		<View className="flex-1 bg-white p-3">
 			<View className="flex-row justify-between items-center mb-2">
 				<View className="flex-row items-center gap-1.5 flex-1 mr-2">
 					{favIconUrl ? (
@@ -206,39 +200,49 @@ export function MemoPanel({
 				</View>
 			</View>
 
-			<TextInput
-				className="min-h-[140px] text-[15px] text-[#333] leading-[22px]"
-				placeholder="이 페이지에 대한 메모를 작성하세요..."
-				value={memoText}
-				onChangeText={setMemoText}
-				multiline
-				scrollEnabled={false}
-				textAlignVertical="top"
-			/>
+			<ScrollView
+				className="flex-1"
+				keyboardShouldPersistTaps="handled"
+				keyboardDismissMode="interactive"
+				contentContainerStyle={{ flexGrow: 1, paddingBottom: 24 }}
+				showsVerticalScrollIndicator={false}
+			>
+				<TextInput
+					className="min-h-[140px] text-[15px] text-[#333] leading-[22px]"
+					placeholder="이 페이지에 대한 메모를 작성하세요..."
+					value={memoText}
+					onChangeText={setMemoText}
+					multiline
+					scrollEnabled={false}
+					textAlignVertical="top"
+				/>
 
-			<Text className="mt-3 text-xs font-semibold text-gray-500">느낀 점</Text>
-			<TextInput
-				className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
-				placeholder="이 페이지에서 느낀 점을 적어보세요"
-				value={impressionText}
-				onChangeText={setImpressionText}
-				multiline
-				scrollEnabled={false}
-				textAlignVertical="top"
-			/>
+				<Text className="mt-3 text-xs font-semibold text-gray-500">
+					느낀 점
+				</Text>
+				<TextInput
+					className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+					placeholder="이 페이지에서 느낀 점을 적어보세요"
+					value={impressionText}
+					onChangeText={setImpressionText}
+					multiline
+					scrollEnabled={false}
+					textAlignVertical="top"
+				/>
 
-			<Text className="mt-3 text-xs font-semibold text-gray-500">
-				액션 아이템
-			</Text>
-			<TextInput
-				className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
-				placeholder="이 페이지를 보고 할 일을 적어보세요"
-				value={actionItemText}
-				onChangeText={setActionItemText}
-				multiline
-				scrollEnabled={false}
-				textAlignVertical="top"
-			/>
-		</ScrollView>
+				<Text className="mt-3 text-xs font-semibold text-gray-500">
+					액션 아이템
+				</Text>
+				<TextInput
+					className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+					placeholder="이 페이지를 보고 할 일을 적어보세요"
+					value={actionItemText}
+					onChangeText={setActionItemText}
+					multiline
+					scrollEnabled={false}
+					textAlignVertical="top"
+				/>
+			</ScrollView>
+		</View>
 	);
 }

--- a/apps/app/app/(main)/index.tsx
+++ b/apps/app/app/(main)/index.tsx
@@ -33,6 +33,7 @@ export default function MemoScreen() {
 		handleEndReached,
 		handleWishRemove,
 		handleStarToggle,
+		handleMemoSave,
 	} = useMemoList();
 
 	useEffect(() => {
@@ -230,6 +231,7 @@ export default function MemoScreen() {
 					setSelectedMemo(null);
 					navigateToBrowser(url);
 				}}
+				onSave={handleMemoSave}
 				onWishRemove={(memo) => {
 					handleWishRemove(memo);
 					setSelectedMemo(null);


### PR DESCRIPTION
## 작업 내용

앱(`apps/app`)의 메모 UX 두 가지를 개선합니다.

### 1. 메모 작성 패널 헤더 상단 고정 (`MemoPanel`)
- 메모·느낀 점·액션 아이템 입력이 길어지면 제목·저장 버튼이 함께 스크롤되어 사라지던 문제 수정.
- 헤더(제목 + 저장 버튼)를 스크롤 영역 밖 고정 영역으로 분리하고, 입력 필드들만 내부 `ScrollView`로 스크롤되도록 재구성.

### 2. 메모 상세 바텀시트에 수정 기능 추가 (`MemoDetailModal`)
- 메모 탭 상세 바텀시트에서 연필 버튼으로 편집 모드 진입 → 메모·느낀 점·액션 아이템을 수정·저장.
- 로그인 시 Supabase, 비로그인 시 로컬 저장소로 upsert (`useMemoList`에 `handleMemoSave` 추가).
- 편집 중 키보드 회피(`KeyboardAvoidingView`) 적용, 위시/중요/공유 버튼은 편집 중 숨김.

## 검증
- `tsc --noEmit` 타입체크 통과
- biome `check` 통과

## 비고
- 이 PR이 master에 머지되면 `cd-app` 워크플로가 iOS 빌드 후 TestFlight에 자동 제출합니다.