### PR TITLE
fix: 웹 MemoDialog 포맷 오류 수정 (CI 통과용)

### DIFF
--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -34,8 +34,10 @@ interface MemoDialog extends LanguageType {
 export default function MemoDialog({ lng, memoId }: MemoDialog) {
 	const { t } = useTranslation(lng);
 	const { memo: memoData } = useMemoQuery({ id: memoId });
-	const { textareaRef: memoTextareaRef, handleTextareaChange: handleMemoChange } =
-		useTextareaAutoResize();
+	const {
+		textareaRef: memoTextareaRef,
+		handleTextareaChange: handleMemoChange,
+	} = useTextareaAutoResize();
 	const {
 		textareaRef: impressionTextareaRef,
 		handleTextareaChange: handleImpressionChange,


### PR DESCRIPTION
## 작업 내용
master에 포맷이 어긋난 채 커밋돼 있던 `apps/web/.../MemoDialog/index.tsx`를 레포 biome 포맷으로 정렬합니다.

## 배경
이 포맷 에러 때문에 `ci` 잡의 `pnpm check`(biome check)가 실패했고, `cd-app`(iOS 빌드 + TestFlight 제출)이 `needs: [ci]` 게이트에서 skip되어 배포가 막혀 있었습니다(직전 master run도 동일 사유로 실패).

## 검증
- `biome check` 통과(해당 파일)
- 순수 포맷 변경(공백/들여쓰기), 로직 변경 없음