### PR TITLE
feat: 메모 상세 바텀시트 편집 중 푸터 숨김

### DIFF
--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -388,23 +388,25 @@ export function MemoDetailModal({
 						</ScrollView>
 					)}
 
-					<View className="flex-row items-center justify-between px-5 pt-2 pb-1">
-						<View className="flex-row items-center gap-2">
-							{domain ? (
-								<View className="flex-row items-center gap-1">
-									<Globe size={11} color="#999" />
+					{!isEditing && (
+						<View className="flex-row items-center justify-between px-5 pt-2 pb-1">
+							<View className="flex-row items-center gap-2">
+								{domain ? (
+									<View className="flex-row items-center gap-1">
+										<Globe size={11} color="#999" />
+										<Text className="text-xs text-muted-foreground">
+											{domain}
+										</Text>
+									</View>
+								) : null}
+								{formattedDate ? (
 									<Text className="text-xs text-muted-foreground">
-										{domain}
+										{formattedDate}
 									</Text>
-								</View>
-							) : null}
-							{formattedDate ? (
-								<Text className="text-xs text-muted-foreground">
-									{formattedDate}
-								</Text>
-							) : null}
+								) : null}
+							</View>
 						</View>
-					</View>
+					)}
 				</Animated.View>
 			</KeyboardAvoidingView>
 		</Modal>


### PR DESCRIPTION
편집 모드에서 도메인·날짜 푸터를 숨겨 입력 영역을 넓힙니다(위시/중요/공유 버튼 숨김과 일관). 

이 PR이 master에 머지되면 app 변경이 포함되어 cd-app(iOS 빌드 + TestFlight 제출)이 실행됩니다.