### PR TITLE
feat: 앱 브라우저 읽기 스크롤 위치 저장·복원 및 읽는 중 배지 추가

### DIFF
--- a/apps/app/app/(main)/_components/MemoCard.tsx
+++ b/apps/app/app/(main)/_components/MemoCard.tsx
@@ -1,5 +1,5 @@
 import type { GetMemoResponse } from "@web-memo/shared/types";
-import { FileText, Heart, Star, Trash2 } from "lucide-react-native";
+import { BookOpen, FileText, Heart, Star, Trash2 } from "lucide-react-native";
 import { useRef } from "react";
 import { Image, Text, TouchableOpacity, View } from "react-native";
 import ReanimatedSwipeable, {
@@ -30,11 +30,18 @@ function formatRelativeDate(dateStr?: string): string {
 
 interface MemoCardProps {
 	memo: MemoItem;
+	/** 0~1 사이의 읽기 진행률. 값이 있으면 '읽는 중' 배지를 표시한다 */
+	readingProgress?: number;
 	onPress: () => void;
 	onDelete: () => void;
 }
 
-export function MemoCard({ memo, onPress, onDelete }: MemoCardProps) {
+export function MemoCard({
+	memo,
+	readingProgress,
+	onPress,
+	onDelete,
+}: MemoCardProps) {
 	const swipeableRef = useRef<SwipeableMethods>(null);
 
 	const rawDate =
@@ -80,6 +87,14 @@ export function MemoCard({ memo, onPress, onDelete }: MemoCardProps) {
 					>
 						{memo.title}
 					</Text>
+					{typeof readingProgress === "number" ? (
+						<View className="flex-row items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-violet-100">
+							<BookOpen size={10} color="#7c3aed" />
+							<Text className="text-[10px] font-semibold text-[#7c3aed]">
+								읽는 중 {Math.round(readingProgress * 100)}%
+							</Text>
+						</View>
+					) : null}
 					{dateLabel ? (
 						<Text className="text-xs text-muted-foreground">{dateLabel}</Text>
 					) : null}

--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -1,4 +1,5 @@
 import { useFocusEffect } from "@react-navigation/native";
+import { useQueryClient } from "@tanstack/react-query";
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -27,7 +28,12 @@ import {
 	useDeleteMemoMutation,
 	useMemoWishToggleMutation,
 } from "@/lib/hooks/useMemoMutation";
+import { SCROLL_POSITIONS_QUERY_KEY } from "@/lib/hooks/useScrollPositions";
 import { shareUrl } from "@/lib/sharing/shareUrl";
+import {
+	getScrollPosition,
+	saveScrollPosition,
+} from "@/lib/storage/scrollPositions";
 import { getPanelRatio, savePanelRatio } from "../_utils/browserPreferences";
 import { formatUrl } from "../_utils/formatUrl";
 import {
@@ -64,6 +70,18 @@ export function useBrowserState() {
 	const [savedRatio, setSavedRatio] = useState(DEFAULT_PANEL_RATIO);
 
 	const { isLoggedIn } = useAuth();
+	const queryClient = useQueryClient();
+
+	// 읽기 위치 저장/복원용 ref (스크롤 메시지는 stale closure를 피하려 ref로 현재 URL 참조)
+	const currentUrlRef = useRef("");
+	currentUrlRef.current = currentUrl;
+	const restoredUrlRef = useRef<string | null>(null);
+	const scrollSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pendingScrollRef = useRef<{
+		url: string;
+		scrollY: number;
+		maxY: number;
+	} | null>(null);
 
 	const { data: supabaseMemo } = useSupabaseMemoByUrl(currentUrl, isLoggedIn);
 	const { data: localMemo } = useLocalMemoByUrl(currentUrl);
@@ -125,8 +143,69 @@ export function useBrowserState() {
 
 		if (navState.loading === false) {
 			webViewRef.current?.injectJavaScript(INJECTED_JS_ON_NAVIGATION);
+
+			if (restoredUrlRef.current !== navState.url) {
+				restoredUrlRef.current = navState.url;
+				restoreScrollPosition(navState.url);
+			}
 		}
 	};
+
+	/** 저장된 읽기 위치가 있으면 해당 위치로 스크롤을 복원한다 */
+	const restoreScrollPosition = async (url: string): Promise<void> => {
+		const saved = await getScrollPosition(url);
+		if (!saved || saved.scrollY <= 0) {
+			return;
+		}
+
+		// ponytail: 로드 직후 레이아웃이 늦게 잡히는 페이지 대비 지연 1회 복원, 부족하면 재시도 로직 추가
+		webViewRef.current?.injectJavaScript(
+			`setTimeout(function() { window.scrollTo(0, ${Math.round(saved.scrollY)}); }, 300); true;`,
+		);
+	};
+
+	/** 스크롤 위치를 스로틀 저장하고 '읽는 중' 배지 쿼리를 갱신한다 */
+	const persistScrollPosition = useCallback(
+		(scrollY: number, maxY: number): void => {
+			const url = currentUrlRef.current;
+			if (!url) {
+				return;
+			}
+
+			pendingScrollRef.current = { url, scrollY, maxY };
+			if (scrollSaveTimerRef.current) {
+				return;
+			}
+
+			scrollSaveTimerRef.current = setTimeout(async () => {
+				scrollSaveTimerRef.current = null;
+				const pending = pendingScrollRef.current;
+				if (!pending) {
+					return;
+				}
+
+				const progress =
+					pending.maxY > 0 ? Math.min(1, pending.scrollY / pending.maxY) : 1;
+				await saveScrollPosition({
+					url: pending.url,
+					scrollY: pending.scrollY,
+					progress,
+				});
+				queryClient.invalidateQueries({
+					queryKey: SCROLL_POSITIONS_QUERY_KEY,
+				});
+			}, 1000);
+		},
+		[queryClient],
+	);
+
+	useEffect(() => {
+		return () => {
+			if (scrollSaveTimerRef.current) {
+				clearTimeout(scrollSaveTimerRef.current);
+			}
+		};
+	}, []);
 
 	const handleUrlSubmit = () => {
 		const url = formatUrl(urlInput);
@@ -243,6 +322,8 @@ export function useBrowserState() {
 	const handleScrollMessage = useCallback(
 		(direction: string, scrollY: number) => {
 			if (isMemoOpen) return;
+			// 최하단 여유 구간: 바운스로 인한 헤더/탭바 토글 버벅임 방지를 위해 상태 유지
+			if (direction === "bottom") return;
 			if (direction === "down") {
 				headerTranslateY.value = withTiming(-HEADER_HEIGHT, {
 					duration: HIDE_DURATION,
@@ -265,11 +346,12 @@ export function useBrowserState() {
 				if (message.type === "favicon" && message.url) {
 					setPageFavIconUrl(message.url);
 				} else if (message.type === "scroll") {
+					persistScrollPosition(message.scrollY, message.maxY ?? 0);
 					handleScrollMessage(message.direction, message.scrollY);
 				}
 			} catch {}
 		},
-		[handleScrollMessage],
+		[handleScrollMessage, persistScrollPosition],
 	);
 
 	const toggleMemo = useCallback(() => {

--- a/apps/app/app/(main)/browser/_utils/webViewScripts.ts
+++ b/apps/app/app/(main)/browser/_utils/webViewScripts.ts
@@ -16,27 +16,35 @@ export const FAVICON_EXTRACT_JS = `
 true;
 `;
 
-/** 스크롤 방향/위치 감지 후 postMessage로 전달 (헤더/탭바 숨김용) */
+/** 스크롤 방향/위치 감지 후 postMessage로 전달 (헤더/탭바 숨김 + 읽기 위치 저장용) */
 export const SCROLL_DETECT_JS = `
 (function() {
   if (window.__webmemoScrollSetup) return;
   window.__webmemoScrollSetup = true;
+  var BOTTOM_MARGIN = 120;
   var lastScrollY = window.scrollY;
   var ticking = false;
   window.addEventListener('scroll', function() {
     if (!ticking) {
       requestAnimationFrame(function() {
-        var currentY = window.scrollY;
+        var maxY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+        var currentY = Math.min(Math.max(0, window.scrollY), maxY);
         if (currentY <= 5) {
           window.ReactNativeWebView.postMessage(JSON.stringify({
-            type: 'scroll', direction: 'top', scrollY: currentY
+            type: 'scroll', direction: 'top', scrollY: currentY, maxY: maxY
+          }));
+          lastScrollY = currentY;
+        } else if (maxY - currentY <= BOTTOM_MARGIN) {
+          // 최하단 여유 구간: iOS 바운스로 방향이 요동쳐 헤더/탭바가 버벅이므로 방향 전환 없이 위치만 전달
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'scroll', direction: 'bottom', scrollY: currentY, maxY: maxY
           }));
           lastScrollY = currentY;
         } else {
           var delta = currentY - lastScrollY;
           if (Math.abs(delta) > 5) {
             window.ReactNativeWebView.postMessage(JSON.stringify({
-              type: 'scroll', direction: delta > 0 ? 'down' : 'up', scrollY: currentY
+              type: 'scroll', direction: delta > 0 ? 'down' : 'up', scrollY: currentY, maxY: maxY
             }));
             lastScrollY = currentY;
           }

--- a/apps/app/app/(main)/index.tsx
+++ b/apps/app/app/(main)/index.tsx
@@ -9,11 +9,14 @@ import {
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useScrollPositions } from "@/lib/hooks/useScrollPositions";
 import { AddMemoModal } from "./_components/AddMemoModal";
 import { MemoCard, type MemoItem } from "./_components/MemoCard";
 import { MemoDetailModal } from "./_components/MemoDetailModal";
 import { useDeleteWithUndo } from "./_hooks/useDeleteWithUndo";
 import { useMemoList } from "./_hooks/useMemoList";
+
+const READ_DONE_PROGRESS = 0.98;
 
 export default function MemoScreen() {
 	const insets = useSafeAreaInsets();
@@ -45,6 +48,20 @@ export default function MemoScreen() {
 	}, [filterParam, setFilter]);
 
 	const { deletedMemo, handleDelete, handleUndo } = useDeleteWithUndo();
+	const { data: scrollPositions } = useScrollPositions();
+
+	const getReadingProgress = (url: string): number | undefined => {
+		const position = scrollPositions?.[url];
+		if (
+			!position ||
+			position.scrollY <= 0 ||
+			position.progress >= READ_DONE_PROGRESS
+		) {
+			return undefined;
+		}
+
+		return position.progress;
+	};
 
 	const navigateToBrowser = useCallback(
 		(url: string) => {
@@ -164,6 +181,7 @@ export default function MemoScreen() {
 							renderItem={({ item }) => (
 								<MemoCard
 									memo={item}
+									readingProgress={getReadingProgress(item.url)}
 									onPress={() => setSelectedMemo(item)}
 									onDelete={() => handleDelete(item)}
 								/>

--- a/apps/app/lib/hooks/useScrollPositions.ts
+++ b/apps/app/lib/hooks/useScrollPositions.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { getScrollPositions } from "@/lib/storage/scrollPositions";
+
+/** 스크롤 위치 쿼리 키 (저장 시 invalidate 용) */
+export const SCROLL_POSITIONS_QUERY_KEY = ["scroll-positions"];
+
+/** URL별 읽기 스크롤 위치 맵을 조회한다 */
+export function useScrollPositions() {
+	return useQuery({
+		queryKey: SCROLL_POSITIONS_QUERY_KEY,
+		queryFn: getScrollPositions,
+	});
+}

--- a/apps/app/lib/storage/scrollPositions.ts
+++ b/apps/app/lib/storage/scrollPositions.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const SCROLL_POSITIONS_KEY = "webmemo:scroll-positions";
+const MAX_ENTRIES = 100;
+
+/** URL별 읽기 스크롤 위치 */
+export interface IFScrollPosition {
+	scrollY: number;
+	/** 0~1 사이의 읽기 진행률 */
+	progress: number;
+	updatedAt: string;
+}
+
+/** URL을 키로 갖는 스크롤 위치 맵 */
+export type TScrollPositionMap = Record<string, IFScrollPosition>;
+
+/** 저장된 전체 스크롤 위치 맵을 반환한다 */
+export async function getScrollPositions(): Promise<TScrollPositionMap> {
+	try {
+		const value = await AsyncStorage.getItem(SCROLL_POSITIONS_KEY);
+
+		return value ? JSON.parse(value) : {};
+	} catch {
+		return {};
+	}
+}
+
+/** 특정 URL의 저장된 스크롤 위치를 반환한다 */
+export async function getScrollPosition(
+	url: string,
+): Promise<IFScrollPosition | null> {
+	const positions = await getScrollPositions();
+
+	return positions[url] ?? null;
+}
+
+/** URL의 스크롤 위치를 저장한다. 최근 항목 MAX_ENTRIES개만 유지한다 */
+export async function saveScrollPosition(params: {
+	url: string;
+	scrollY: number;
+	progress: number;
+}): Promise<void> {
+	try {
+		const positions = await getScrollPositions();
+		positions[params.url] = {
+			scrollY: params.scrollY,
+			progress: params.progress,
+			updatedAt: new Date().toISOString(),
+		};
+
+		const entries = Object.entries(positions)
+			.sort((a, b) => (a[1].updatedAt < b[1].updatedAt ? 1 : -1))
+			.slice(0, MAX_ENTRIES);
+
+		await AsyncStorage.setItem(
+			SCROLL_POSITIONS_KEY,
+			JSON.stringify(Object.fromEntries(entries)),
+		);
+	} catch {}
+}


### PR DESCRIPTION
## Description
앱 브라우저 탭의 아티클 읽기 경험 개선 3건.

- 아티클을 다시 열면 이전에 읽던 스크롤 위치로 자동 복원 (URL별 위치를 AsyncStorage에 저장)
- 페이지 최하단에서 iOS 바운스로 헤더/탭바가 반복 토글되던 버벅임 해결 (하단 120px 여유 구간에서는 방향 전환 무시)
- 메모 탭 카드에 읽기 진행률 기반 '읽는 중 XX%' 배지 추가 (98% 이상이면 완독으로 간주해 미표시)

## Related Issue
N/A

## Type of Change
- [x] Feature (new feature)
- [ ] Fix (bug fix)
- [ ] Chore (maintenance, dependencies)
- [ ] Refactor (code restructuring)

## How Has This Been Tested?
- `pnpm tsc --noEmit` (apps/app) 통과
- `biome check` 통과 (잔여 warning은 미변경 파일의 기존 항목)

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
