### PR TITLE
feat: 메모 상세 바텀시트 제목 수정 기능 추가

### DIFF
--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -47,7 +47,12 @@ interface MemoDetailModalProps {
 	onStarToggle?: (memo: MemoItem) => void;
 	onSave?: (
 		memo: MemoItem,
-		next: { memo: string; impression: string; actionItem: string },
+		next: {
+			title: string;
+			memo: string;
+			impression: string;
+			actionItem: string;
+		},
 	) => void;
 }
 
@@ -64,6 +69,7 @@ export function MemoDetailModal({
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
 	const [isEditing, setIsEditing] = useState(false);
+	const [editedTitle, setEditedTitle] = useState("");
 	const [editedMemo, setEditedMemo] = useState("");
 	const [editedImpression, setEditedImpression] = useState("");
 	const [editedActionItem, setEditedActionItem] = useState("");
@@ -87,6 +93,7 @@ export function MemoDetailModal({
 	useEffect(
 		function syncEditState() {
 			if (memo) {
+				setEditedTitle(memo.title ?? "");
 				setEditedMemo(memo.memo ?? "");
 				setEditedImpression(memo.impression ?? "");
 				setEditedActionItem(memo.actionItem ?? "");
@@ -135,6 +142,7 @@ export function MemoDetailModal({
 	const actionItemText = memo?.actionItem ?? "";
 
 	const handleStartEdit = () => {
+		setEditedTitle(title);
 		setEditedMemo(memoText);
 		setEditedImpression(impressionText);
 		setEditedActionItem(actionItemText);
@@ -142,6 +150,7 @@ export function MemoDetailModal({
 	};
 
 	const handleCancelEdit = () => {
+		setEditedTitle(title);
 		setEditedMemo(memoText);
 		setEditedImpression(impressionText);
 		setEditedActionItem(actionItemText);
@@ -153,6 +162,7 @@ export function MemoDetailModal({
 		if (!memo) return;
 
 		onSave?.(memo, {
+			title: editedTitle.trim() || title,
 			memo: editedMemo.trim(),
 			impression: editedImpression.trim(),
 			actionItem: editedActionItem.trim(),
@@ -164,6 +174,7 @@ export function MemoDetailModal({
 	};
 
 	const isMemoEdited =
+		(editedTitle.trim() !== "" && editedTitle.trim() !== title.trim()) ||
 		editedMemo.trim() !== memoText.trim() ||
 		editedImpression.trim() !== impressionText.trim() ||
 		editedActionItem.trim() !== actionItemText.trim();
@@ -214,7 +225,14 @@ export function MemoDetailModal({
 						) : (
 							<FileText size={14} color="#666" />
 						)}
-						{isWebUrl ? (
+						{isEditing ? (
+							<TextInput
+								className="flex-1 p-0 text-base font-semibold text-foreground"
+								value={editedTitle}
+								onChangeText={setEditedTitle}
+								placeholder="제목을 입력하세요"
+							/>
+						) : isWebUrl ? (
 							<TouchableOpacity
 								className="flex-1"
 								onPress={handleNavigate}

--- a/apps/app/app/(main)/_hooks/useMemoList.ts
+++ b/apps/app/app/(main)/_hooks/useMemoList.ts
@@ -98,14 +98,19 @@ export function useMemoList() {
 
 	const handleMemoSave = (
 		memo: MemoItem,
-		next: { memo: string; impression: string; actionItem: string },
+		next: {
+			title: string;
+			memo: string;
+			impression: string;
+			actionItem: string;
+		},
 	) => {
 		const favIconUrl =
 			"favIconUrl" in memo ? (memo.favIconUrl ?? undefined) : undefined;
 		if (isLoggedIn) {
 			upsertSupabase.mutate({
 				url: memo.url,
-				title: memo.title,
+				title: next.title,
 				memo: next.memo,
 				impression: next.impression,
 				actionItem: next.actionItem,
@@ -114,7 +119,7 @@ export function useMemoList() {
 		} else {
 			upsertLocal.mutate({
 				url: memo.url,
-				title: memo.title,
+				title: next.title,
 				memo: next.memo,
 				impression: next.impression,
 				actionItem: next.actionItem,


### PR DESCRIPTION
## 개요

앱 메모 상세 바텀시트에서 제목을 수정할 수 있도록 합니다.

## 작업 사항

- 메모 상세 바텀시트 편집 모드에서 제목을 TextInput으로 수정 가능하게 변경

- 저장 시 수정된 제목을 Supabase/로컬 저장 양쪽에 반영 (빈 제목은 기존 제목 유지)
