### PR TITLE
느낀점/액션아이템 필드 표시 설정 추가

### DIFF
--- a/apps/app/app/(main)/_components/AddMemoModal.tsx
+++ b/apps/app/app/(main)/_components/AddMemoModal.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { useLocalMemoUpsert } from "@/lib/hooks/useLocalMemos";
 import { useMemoUpsertMutation } from "@/lib/hooks/useMemoMutation";
+import { useSettingQuery } from "@/lib/hooks/useSetting";
 import {
 	extractPageMetadata,
 	getFavIconUrl,
@@ -34,6 +35,7 @@ interface AddMemoModalProps {
 export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 	const insets = useSafeAreaInsets();
 	const { isLoggedIn } = useAuth();
+	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
 
 	const [titleText, setTitleText] = useState("");
 	const [urlText, setUrlText] = useState("");
@@ -203,31 +205,39 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 							textAlignVertical="top"
 						/>
 
-						<Text className="mt-3 text-xs font-semibold text-gray-500">
-							느낀 점
-						</Text>
-						<TextInput
-							className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
-							placeholder="느낀 점을 적어보세요"
-							value={impressionText}
-							onChangeText={setImpressionText}
-							multiline
-							scrollEnabled={false}
-							textAlignVertical="top"
-						/>
+						{showImpression && (
+							<>
+								<Text className="mt-3 text-xs font-semibold text-gray-500">
+									느낀 점
+								</Text>
+								<TextInput
+									className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+									placeholder="느낀 점을 적어보세요"
+									value={impressionText}
+									onChangeText={setImpressionText}
+									multiline
+									scrollEnabled={false}
+									textAlignVertical="top"
+								/>
+							</>
+						)}
 
-						<Text className="mt-3 text-xs font-semibold text-gray-500">
-							액션 아이템
-						</Text>
-						<TextInput
-							className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
-							placeholder="할 일을 적어보세요"
-							value={actionItemText}
-							onChangeText={setActionItemText}
-							multiline
-							scrollEnabled={false}
-							textAlignVertical="top"
-						/>
+						{showActionItem && (
+							<>
+								<Text className="mt-3 text-xs font-semibold text-gray-500">
+									액션 아이템
+								</Text>
+								<TextInput
+									className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+									placeholder="할 일을 적어보세요"
+									value={actionItemText}
+									onChangeText={setActionItemText}
+									multiline
+									scrollEnabled={false}
+									textAlignVertical="top"
+								/>
+							</>
+						)}
 					</ScrollView>
 				</View>
 			</KeyboardAvoidingView>

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -31,6 +31,8 @@ import Animated, {
 	withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { useSettingQuery } from "@/lib/hooks/useSetting";
 import { shareUrl } from "@/lib/sharing/shareUrl";
 import { extractDomain } from "../_utils/extractDomain";
 import { formatDate } from "../_utils/formatDate";
@@ -65,6 +67,8 @@ export function MemoDetailModal({
 	onSave,
 }: MemoDetailModalProps) {
 	const insets = useSafeAreaInsets();
+	const { isLoggedIn } = useAuth();
+	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
@@ -343,30 +347,38 @@ export function MemoDetailModal({
 								scrollEnabled={false}
 								autoFocus
 							/>
-							<Text className="mt-3 text-xs font-semibold text-gray-500">
-								느낀 점
-							</Text>
-							<TextInput
-								className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
-								value={editedImpression}
-								onChangeText={setEditedImpression}
-								placeholder="이 페이지에서 느낀 점을 적어보세요"
-								multiline
-								textAlignVertical="top"
-								scrollEnabled={false}
-							/>
-							<Text className="mt-3 text-xs font-semibold text-gray-500">
-								액션 아이템
-							</Text>
-							<TextInput
-								className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
-								value={editedActionItem}
-								onChangeText={setEditedActionItem}
-								placeholder="이 페이지를 보고 할 일을 적어보세요"
-								multiline
-								textAlignVertical="top"
-								scrollEnabled={false}
-							/>
+							{showImpression && (
+								<>
+									<Text className="mt-3 text-xs font-semibold text-gray-500">
+										느낀 점
+									</Text>
+									<TextInput
+										className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
+										value={editedImpression}
+										onChangeText={setEditedImpression}
+										placeholder="이 페이지에서 느낀 점을 적어보세요"
+										multiline
+										textAlignVertical="top"
+										scrollEnabled={false}
+									/>
+								</>
+							)}
+							{showActionItem && (
+								<>
+									<Text className="mt-3 text-xs font-semibold text-gray-500">
+										액션 아이템
+									</Text>
+									<TextInput
+										className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
+										value={editedActionItem}
+										onChangeText={setEditedActionItem}
+										placeholder="이 페이지를 보고 할 일을 적어보세요"
+										multiline
+										textAlignVertical="top"
+										scrollEnabled={false}
+									/>
+								</>
+							)}
 						</ScrollView>
 					) : (
 						<ScrollView

--- a/apps/app/app/(main)/settings/index.tsx
+++ b/apps/app/app/(main)/settings/index.tsx
@@ -7,14 +7,27 @@ import {
 	MessageCircle,
 	User,
 } from "lucide-react-native";
-import { Alert, Linking, Text, TouchableOpacity, View } from "react-native";
+import {
+	Alert,
+	Linking,
+	Switch,
+	Text,
+	TouchableOpacity,
+	View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuth } from "@/lib/auth/AuthProvider";
+import {
+	useSettingQuery,
+	useSettingUpsertMutation,
+} from "@/lib/hooks/useSetting";
 
 export default function SettingsScreen() {
 	const insets = useSafeAreaInsets();
 	const router = useRouter();
 	const { session, signOut, isLoggedIn } = useAuth();
+	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
+	const { mutate: upsertSetting } = useSettingUpsertMutation();
 
 	const handleSignOut = () => {
 		Alert.alert("로그아웃", "로그아웃 하시겠습니까?", [
@@ -82,6 +95,39 @@ export default function SettingsScreen() {
 						)}
 					</View>
 				</View>
+
+				{/* Memo Fields Section */}
+				{isLoggedIn && (
+					<View className="mb-7">
+						<Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2.5">
+							메모 입력 항목
+						</Text>
+						<View className="bg-card rounded-[14px] p-4 border border-muted gap-3">
+							<View className="flex-row justify-between items-center py-1">
+								<Text className="text-[15px] text-secondary-foreground">
+									느낀 점 입력란 표시
+								</Text>
+								<Switch
+									value={showImpression}
+									onValueChange={(value) =>
+										upsertSetting({ show_impression: value })
+									}
+								/>
+							</View>
+							<View className="flex-row justify-between items-center py-1">
+								<Text className="text-[15px] text-secondary-foreground">
+									액션 아이템 입력란 표시
+								</Text>
+								<Switch
+									value={showActionItem}
+									onValueChange={(value) =>
+										upsertSetting({ show_action_item: value })
+									}
+								/>
+							</View>
+						</View>
+					</View>
+				)}
 
 				{/* App Info Section */}
 				<View className="mb-7">

--- a/apps/app/lib/hooks/useSetting.ts
+++ b/apps/app/lib/hooks/useSetting.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEY } from "@web-memo/shared/constants";
+import type { SettingTable } from "@web-memo/shared/types";
+import { settingService } from "@/lib/supabase/client";
+
+export function useSettingQuery(isLoggedIn: boolean) {
+	const query = useQuery({
+		queryKey: QUERY_KEY.setting(),
+		queryFn: async () => {
+			const result = await settingService.getSetting();
+			return result.data;
+		},
+		enabled: isLoggedIn,
+	});
+
+	return {
+		...query,
+		showImpression: query.data?.show_impression ?? true,
+		showActionItem: query.data?.show_action_item ?? true,
+	};
+}
+
+export function useSettingUpsertMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (request: Omit<SettingTable["Insert"], "user_id">) =>
+			settingService.upsertSetting(request),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: QUERY_KEY.setting() });
+		},
+	});
+}

--- a/apps/app/lib/supabase/client.ts
+++ b/apps/app/lib/supabase/client.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@web-memo/shared/types";
-import { MemoService } from "@web-memo/shared/utils/services";
+import { MemoService, SettingService } from "@web-memo/shared/utils/services";
 import * as SecureStore from "expo-secure-store";
 import { Platform } from "react-native";
 import { CONFIG } from "@/lib/config";
@@ -43,3 +43,4 @@ export const supabase = createClient<Database, "memo">(
 );
 
 export const memoService = new MemoService(supabase);
+export const settingService = new SettingService(supabase);

--- a/apps/chrome-extension/public/_locales/en/messages.json
+++ b/apps/chrome-extension/public/_locales/en/messages.json
@@ -146,6 +146,15 @@
 	"auto_apply_category_description": {
 		"message": "Automatically apply AI-suggested categories"
 	},
+	"memo_fields_setting": {
+		"message": "Memo fields"
+	},
+	"show_impression_setting": {
+		"message": "Show impression field"
+	},
+	"show_action_item_setting": {
+		"message": "Show action item field"
+	},
 	"chat_title": {
 		"message": "AI Chat"
 	},

--- a/apps/chrome-extension/public/_locales/ko/messages.json
+++ b/apps/chrome-extension/public/_locales/ko/messages.json
@@ -146,6 +146,15 @@
 	"auto_apply_category_description": {
 		"message": "AI가 추천한 카테고리를 자동으로 적용합니다"
 	},
+	"memo_fields_setting": {
+		"message": "메모 입력 항목"
+	},
+	"show_impression_setting": {
+		"message": "느낀 점 입력란 표시"
+	},
+	"show_action_item_setting": {
+		"message": "액션 아이템 입력란 표시"
+	},
 	"chat_title": {
 		"message": "AI 채팅"
 	},

--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -8,6 +8,7 @@ import {
 	useKeyboardBind,
 	useMemoPatchMutation,
 	useMemoQuery,
+	useSettingQuery,
 	useTextareaAutoResize,
 } from "@web-memo/shared/hooks";
 import { useSearchParams } from "@web-memo/shared/modules/search-params";
@@ -34,6 +35,7 @@ interface MemoDialog extends LanguageType {
 export default function MemoDialog({ lng, memoId }: MemoDialog) {
 	const { t } = useTranslation(lng);
 	const { memo: memoData } = useMemoQuery({ id: memoId });
+	const { showImpression, showActionItem } = useSettingQuery();
 	const {
 		textareaRef: memoTextareaRef,
 		handleTextareaChange: handleMemoChange,
@@ -201,35 +203,43 @@ export default function MemoDialog({ lng, memoId }: MemoDialog) {
 								data-testid="memo-textarea"
 							/>
 
-							<label
-								htmlFor="impression"
-								className="mt-3 text-xs font-semibold text-gray-500"
-							>
-								{t("memoSection.impression")}
-							</label>
-							<Textarea
-								{...impressionRest}
-								id="impression"
-								className="resize-none overflow-hidden outline-none focus:border-gray-300 focus:outline-none"
-								ref={impressionTextareaRef}
-								placeholder={t("memoSection.impressionPlaceholder")}
-								data-testid="impression-textarea"
-							/>
+							{showImpression && (
+								<>
+									<label
+										htmlFor="impression"
+										className="mt-3 text-xs font-semibold text-gray-500"
+									>
+										{t("memoSection.impression")}
+									</label>
+									<Textarea
+										{...impressionRest}
+										id="impression"
+										className="resize-none overflow-hidden outline-none focus:border-gray-300 focus:outline-none"
+										ref={impressionTextareaRef}
+										placeholder={t("memoSection.impressionPlaceholder")}
+										data-testid="impression-textarea"
+									/>
+								</>
+							)}
 
-							<label
-								htmlFor="actionItem"
-								className="mt-3 text-xs font-semibold text-gray-500"
-							>
-								{t("memoSection.actionItem")}
-							</label>
-							<Textarea
-								{...actionItemRest}
-								id="actionItem"
-								className="resize-none overflow-hidden outline-none focus:border-gray-300 focus:outline-none"
-								ref={actionItemTextareaRef}
-								placeholder={t("memoSection.actionItemPlaceholder")}
-								data-testid="action-item-textarea"
-							/>
+							{showActionItem && (
+								<>
+									<label
+										htmlFor="actionItem"
+										className="mt-3 text-xs font-semibold text-gray-500"
+									>
+										{t("memoSection.actionItem")}
+									</label>
+									<Textarea
+										{...actionItemRest}
+										id="actionItem"
+										className="resize-none overflow-hidden outline-none focus:border-gray-300 focus:outline-none"
+										ref={actionItemTextareaRef}
+										placeholder={t("memoSection.actionItemPlaceholder")}
+										data-testid="action-item-textarea"
+									/>
+								</>
+							)}
 
 							<div className="mt-3 flex h-4 items-center">
 								<SaveStatusIndicator status={saveStatus} lng={lng} />

--- a/apps/web/src/app/[lng]/(auth)/memos/setting/_components/Setting/SettingMemoFields.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/setting/_components/Setting/SettingMemoFields.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { LanguageType } from "@src/modules/i18n";
+import useTranslation from "@src/modules/i18n/util.client";
+import {
+	useSettingQuery,
+	useSettingUpsertMutation,
+} from "@web-memo/shared/hooks";
+import { Label, Switch } from "@web-memo/ui";
+
+export default function SettingMemoFields({ lng }: SettingMemoFieldsProps) {
+	const { t } = useTranslation(lng);
+	const { showImpression, showActionItem } = useSettingQuery();
+	const { mutate: upsertSetting } = useSettingUpsertMutation();
+
+	return (
+		<div className="grid gap-3">
+			<Label className="text-center">{t("setting.memoFields")}</Label>
+			<div className="mx-auto flex w-full max-w-xs flex-col gap-3">
+				<div className="flex items-center justify-between">
+					<Label htmlFor="show-impression">{t("memoSection.impression")}</Label>
+					<Switch
+						id="show-impression"
+						checked={showImpression}
+						onCheckedChange={(checked) =>
+							upsertSetting({ show_impression: checked })
+						}
+					/>
+				</div>
+				<div className="flex items-center justify-between">
+					<Label htmlFor="show-action-item">
+						{t("memoSection.actionItem")}
+					</Label>
+					<Switch
+						id="show-action-item"
+						checked={showActionItem}
+						onCheckedChange={(checked) =>
+							upsertSetting({ show_action_item: checked })
+						}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface SettingMemoFieldsProps extends LanguageType {}

--- a/apps/web/src/app/[lng]/(auth)/memos/setting/_components/Setting/index.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/setting/_components/Setting/index.tsx
@@ -10,6 +10,7 @@ import SettingCategoryForm from "./SettingCategoryForm";
 import SettingExport from "./SettingExport";
 import SettingGuide from "./SettingGuide";
 import SettingLanguage from "./SettingLanguage";
+import SettingMemoFields from "./SettingMemoFields";
 
 interface SettingProps extends LanguageType {}
 
@@ -24,6 +25,7 @@ export default function Setting({ lng }: SettingProps) {
 		>
 			<Suspense fallback={<Loading />}>
 				<SettingLanguage lng={lng} />
+				<SettingMemoFields lng={lng} />
 				<SettingGuide lng={lng} />
 				<SettingExport lng={lng} />
 				<SettingCategoryForm lng={lng} />

--- a/apps/web/src/app/[lng]/(no-auth)/introduce/_utils/metadata.ts
+++ b/apps/web/src/app/[lng]/(no-auth)/introduce/_utils/metadata.ts
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const metadataKorean: Metadata = {
-	title: "웹 메모 | 소개 ",
+	title: "웹 메모 - 웹페이지 읽으며 바로 메모하는 크롬 확장",
 	description:
-		"웹 메모는 웹페이지를 읽으며 생각을 즉시 기록할 수 있는 서비스입니다. 아티클을 읽다가 떠오른 아이디어나 중요한 내용을 사이드 패널에서 바로 메모하고 체계적으로 관리하세요.",
+		"웹 메모는 웹페이지를 읽으며 생각을 즉시 기록하는 크롬 확장 프로그램입니다. 사이드 패널에서 아티클을 바로 메모하고, 유튜브 영상을 AI로 요약하며, 저장한 메모를 체계적으로 관리하세요. 무료로 시작하세요.",
 	alternates: {
 		canonical: "https://webmemo.site/ko/introduce",
 		languages: {
@@ -17,9 +17,9 @@ export const metadataKorean: Metadata = {
 };
 
 export const metadataEnglish: Metadata = {
-	title: "Web Memo | Introduce",
+	title: "Web Memo - Take Notes While Browsing | Chrome Extension",
 	description:
-		"Web Memo is a service that lets you instantly record your thoughts while reading web pages. Save ideas and important content that come to mind while reading articles through the side panel and manage them systematically.",
+		"Web Memo is a Chrome extension that lets you instantly capture thoughts while reading web pages. Take notes on articles from the side panel, summarize YouTube videos with AI, and organize your saved memos systematically. Free to start.",
 	alternates: {
 		canonical: "https://webmemo.site/en/introduce",
 		languages: {

--- a/apps/web/src/app/[lng]/_components/HtmlLang.tsx
+++ b/apps/web/src/app/[lng]/_components/HtmlLang.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { Language } from "@src/modules/i18n";
+import { useEffect } from "react";
+
+/**
+ * 문서 최상위 `<html lang>`을 현재 로케일로 교정한다.
+ *
+ * @description
+ * root layout(`app/layout.tsx`)이 `[lng]` 세그먼트 위에 있어 `<html lang>`이
+ * "ko"로 고정돼 있다. SSR에서 정확히 맞추려면 root에서 headers()를 읽어야 하는데,
+ * 그러면 전 페이지가 동적 렌더링으로 바뀌어 정적 생성 이점을 잃는다.
+ * ponytail: JS 렌더링 크롤러(Googlebot) 기준으로만 교정한다. 완전한 SSR 정확성이
+ * 필요해지면 middleware에서 x-lng 헤더를 내려 root layout이 읽도록 승급.
+ */
+interface HtmlLangProps {
+	lng: Language;
+}
+
+export default function HtmlLang({ lng }: HtmlLangProps) {
+	useEffect(() => {
+		document.documentElement.lang = lng;
+	}, [lng]);
+
+	return null;
+}

--- a/apps/web/src/app/[lng]/_components/index.ts
+++ b/apps/web/src/app/[lng]/_components/index.ts
@@ -1,3 +1,4 @@
+export { default as HtmlLang } from "./HtmlLang";
 export { default as QueryProvider } from "./QueryProvider";
 export { default as ThemeProvider } from "./ThemeProvider";
 export { default as UpdateNotificationDialog } from "./UpdateNotificationDialog";

--- a/apps/web/src/app/[lng]/layout.tsx
+++ b/apps/web/src/app/[lng]/layout.tsx
@@ -5,7 +5,7 @@ import { AnalyticsUserTracking } from "@web-memo/shared/modules/analytics";
 import { dir } from "i18next";
 import { type PropsWithChildren, Suspense } from "react";
 import { InitDayjs, JsonLD } from "../_components";
-import { QueryProvider, ThemeProvider } from "./_components";
+import { HtmlLang, QueryProvider, ThemeProvider } from "./_components";
 import { metadataEnglish, metadataKorean } from "./_constants";
 
 interface RootLayoutProps extends PropsWithChildren, LanguageParams {}
@@ -24,6 +24,7 @@ export default function RootLayout({
 }: RootLayoutProps) {
 	return (
 		<div lang={lng} dir={dir(lng)} className="h-screen">
+			<HtmlLang lng={lng} />
 			<JsonLD lng={lng} />
 			<ThemeProvider>
 				<QueryProvider lng={lng}>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,7 +5,7 @@ import "./globals.css";
 import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import { CONFIG } from "@web-memo/env";
 import { Toaster } from "@web-memo/ui";
-import type { Viewport } from "next";
+import type { Metadata, Viewport } from "next";
 import type { PropsWithChildren } from "react";
 import { WebVitals } from "./_components";
 
@@ -16,6 +16,18 @@ export const viewport: Viewport = {
 	initialScale: 1,
 	maximumScale: 1,
 	userScalable: false,
+};
+
+/**
+ * 전역 메타데이터 기본값.
+ * metadataBase로 하위 페이지의 상대경로 OG/Twitter 이미지를 절대 URL로 해석한다.
+ */
+export const metadata: Metadata = {
+	metadataBase: new URL(CONFIG.webUrl),
+	twitter: {
+		card: "summary_large_image",
+		images: ["/og-image.png"],
+	},
 };
 
 export default function Layout({ children }: LayoutProps) {

--- a/apps/web/src/modules/i18n/locales/en/translation.json
+++ b/apps/web/src/modules/i18n/locales/en/translation.json
@@ -429,6 +429,7 @@
 		"language": "Language",
 		"guide": "Guide",
 		"restartGuide": "Restart guide",
+		"memoFields": "Memo Fields",
 		"category": "Category",
 		"addCategory": "Add category",
 		"deleteCategory": "Delete category",

--- a/apps/web/src/modules/i18n/locales/ko/translation.json
+++ b/apps/web/src/modules/i18n/locales/ko/translation.json
@@ -424,6 +424,7 @@
 		"language": "언어",
 		"guide": "가이드",
 		"restartGuide": "가이드 다시 보기",
+		"memoFields": "메모 입력 항목",
 		"category": "카테고리",
 		"addCategory": "카테고리 추가하기",
 		"deleteCategory": "카테고리 삭제하기",

--- a/packages/shared/src/constants/QueryKey.ts
+++ b/packages/shared/src/constants/QueryKey.ts
@@ -20,6 +20,7 @@ export const QUERY_KEY = {
 	supabaseClient: () => ["supabaseClient"],
 	user: () => ["user"],
 	category: () => ["cateogory"],
+	setting: () => ["setting"],
 	adminStats: () => ["adminStats"],
 	activeUsersStats: () => ["activeUsersStats"],
 	userGrowth: (days: number) => ["userGrowth", days],

--- a/packages/shared/src/constants/Supabase.ts
+++ b/packages/shared/src/constants/Supabase.ts
@@ -10,5 +10,6 @@ export const SUPABASE = {
 	table: {
 		memo: "memo",
 		category: "category",
+		setting: "setting",
 	},
 } as const;

--- a/packages/shared/src/hooks/supabase/mutations/index.ts
+++ b/packages/shared/src/hooks/supabase/mutations/index.ts
@@ -8,4 +8,5 @@ export { default as useMemoPatchMutation } from "./useMemoPatchMutation";
 export { default as useMemoPostMutation } from "./useMemoPostMutation";
 export { default as useMemosUpsertMutation } from "./useMemosUpsertMutation";
 export { default as useMemoUpsertMutation } from "./useMemoUpsertMutation";
+export { default as useSettingUpsertMutation } from "./useSettingUpsertMutation";
 export { default as useSignoutMutation } from "./useSignoutMutation";

--- a/packages/shared/src/hooks/supabase/mutations/useSettingUpsertMutation.ts
+++ b/packages/shared/src/hooks/supabase/mutations/useSettingUpsertMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEY } from "../../../constants";
+import { SettingService } from "../../../utils";
+
+import { useSupabaseClientQuery } from "../queries";
+
+export default function useSettingUpsertMutation() {
+	const queryClient = useQueryClient();
+	const { data: supabaseClient } = useSupabaseClientQuery();
+
+	return useMutation({
+		mutationFn: new SettingService(supabaseClient).upsertSetting,
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: QUERY_KEY.setting() });
+		},
+	});
+}

--- a/packages/shared/src/hooks/supabase/queries/index.ts
+++ b/packages/shared/src/hooks/supabase/queries/index.ts
@@ -4,6 +4,7 @@ export { default as useAdminUsersQuery } from "./useAdminUsersQuery";
 export { default as useCategoryQuery } from "./useCategoryQuery";
 export { default as useMemoQuery } from "./useMemoQuery";
 export { default as useMemosInfiniteQuery } from "./useMemosInfiniteQuery";
+export { default as useSettingQuery } from "./useSettingQuery";
 export { default as useSupabaseClientQuery } from "./useSupabaseClientQuery";
 export { default as useSupabaseFeedbackClientQuery } from "./useSupabaseFeedbackClientQuery";
 export { default as useSupabaseUserQuery } from "./useSupabaseUserQuery";

--- a/packages/shared/src/hooks/supabase/queries/useSettingQuery.ts
+++ b/packages/shared/src/hooks/supabase/queries/useSettingQuery.ts
@@ -1,0 +1,21 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { QUERY_KEY } from "../../../constants";
+import { SettingService } from "../../../utils";
+
+import useSupabaseClientQuery from "./useSupabaseClientQuery";
+
+export default function useSettingQuery() {
+	const { data: supabaseClient } = useSupabaseClientQuery();
+
+	const query = useSuspenseQuery({
+		queryFn: new SettingService(supabaseClient).getSetting,
+		queryKey: QUERY_KEY.setting(),
+		staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
+	});
+
+	return {
+		...query,
+		showImpression: query.data?.data?.show_impression ?? true,
+		showActionItem: query.data?.data?.show_action_item ?? true,
+	};
+}

--- a/packages/shared/src/types/supabase.ts
+++ b/packages/shared/src/types/supabase.ts
@@ -153,14 +153,20 @@ export type Database = {
 			setting: {
 				Row: {
 					id: number;
+					show_action_item: boolean;
+					show_impression: boolean;
 					user_id: string | null;
 				};
 				Insert: {
 					id?: number;
+					show_action_item?: boolean;
+					show_impression?: boolean;
 					user_id?: string | null;
 				};
 				Update: {
 					id?: number;
+					show_action_item?: boolean;
+					show_impression?: boolean;
 					user_id?: string | null;
 				};
 				Relationships: [];

--- a/packages/shared/src/types/supabaseCustom.ts
+++ b/packages/shared/src/types/supabaseCustom.ts
@@ -23,6 +23,9 @@ export type CategorySupabaseResponse = PostgrestSingleResponse<
 	Array<CategoryTable["Row"]>
 >;
 
+export type SettingTable = Database["memo"]["Tables"]["setting"];
+export type SettingRow = SettingTable["Row"];
+
 export type GetMemoResponse = QueryData<
 	ReturnType<MemoService["getMemos"]>
 >[number];

--- a/packages/shared/src/utils/Supabase.ts
+++ b/packages/shared/src/utils/Supabase.ts
@@ -8,6 +8,7 @@ import type {
 	MemoRow,
 	MemoSupabaseClient,
 	MemoTable,
+	SettingTable,
 } from "../types";
 import { getMemoSearchFilter } from "./memoSearchFilter";
 
@@ -229,6 +230,34 @@ export class CategoryService {
 			.delete()
 			.eq("id", id)
 			.select();
+}
+
+export class SettingService {
+	supabaseClient: MemoSupabaseClient;
+
+	constructor(supabaseClient: MemoSupabaseClient) {
+		this.supabaseClient = supabaseClient;
+	}
+
+	getSetting = async () =>
+		this.supabaseClient
+			.schema(SUPABASE.table.memo)
+			.from(SUPABASE.table.setting)
+			.select("*")
+			.maybeSingle();
+
+	upsertSetting = async (request: Omit<SettingTable["Insert"], "user_id">) => {
+		const {
+			data: { user },
+		} = await this.supabaseClient.auth.getUser();
+
+		return this.supabaseClient
+			.schema(SUPABASE.table.memo)
+			.from(SUPABASE.table.setting)
+			.upsert({ ...request, user_id: user?.id }, { onConflict: "user_id" })
+			.select()
+			.single();
+	};
 }
 
 export class AuthService {

--- a/packages/supabase-edge-functions/supabase/migrations/20260727_add_field_toggles_to_setting.sql
+++ b/packages/supabase-edge-functions/supabase/migrations/20260727_add_field_toggles_to_setting.sql
@@ -1,0 +1,30 @@
+-- 확장프로그램·앱·웹이 공통으로 참조하는 "느낀점/액션아이템 입력란 표시 여부" 설정 컬럼 추가.
+ALTER TABLE memo.setting
+  ADD COLUMN IF NOT EXISTS "show_impression" boolean NOT NULL DEFAULT true;
+ALTER TABLE memo.setting
+  ADD COLUMN IF NOT EXISTS "show_action_item" boolean NOT NULL DEFAULT true;
+
+-- user_id 기준 upsert(on_conflict)를 지원하려면 유니크 제약이 필요.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'setting_user_id_key'
+  ) THEN
+    ALTER TABLE memo.setting ADD CONSTRAINT setting_user_id_key UNIQUE (user_id);
+  END IF;
+END $$;
+
+ALTER TABLE memo.setting ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'memo' AND tablename = 'setting' AND policyname = 'setting_owner_access'
+  ) THEN
+    CREATE POLICY setting_owner_access ON memo.setting
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -1,14 +1,18 @@
 import "@src/Options.css";
 
 import { Toaster } from "@web-memo/ui";
+import { Suspense } from "react";
 
-import { Header, Option, QueryProvider } from "./components";
+import { Header, MemoFieldsOption, Option, QueryProvider } from "./components";
 
 export default function Options() {
 	return (
 		<QueryProvider>
 			<main className="mx-auto max-w-[1000px] px-8 text-start text-base">
 				<Header />
+				<Suspense fallback={null}>
+					<MemoFieldsOption />
+				</Suspense>
 				<Option />
 			</main>
 			<Toaster />

--- a/pages/options/src/components/MemoFieldsOption.tsx
+++ b/pages/options/src/components/MemoFieldsOption.tsx
@@ -1,0 +1,51 @@
+import {
+	useSettingQuery,
+	useSettingUpsertMutation,
+} from "@web-memo/shared/hooks";
+import { I18n } from "@web-memo/shared/utils/extension";
+import { Label, Switch } from "@web-memo/ui";
+
+export default function MemoFieldsOption() {
+	const { showImpression, showActionItem } = useSettingQuery();
+	const { mutate: upsertSetting } = useSettingUpsertMutation();
+
+	return (
+		<section className="mb-8">
+			<h2 className="mb-4 text-xl font-semibold">
+				{I18n.get("memo_fields_setting")}
+			</h2>
+			<div className="flex flex-col gap-3">
+				<div className="flex items-center space-x-3">
+					<Switch
+						id="show-impression"
+						checked={showImpression}
+						onCheckedChange={(checked) =>
+							upsertSetting({ show_impression: checked })
+						}
+					/>
+					<Label
+						htmlFor="show-impression"
+						className="text-sm text-muted-foreground"
+					>
+						{I18n.get("show_impression_setting")}
+					</Label>
+				</div>
+				<div className="flex items-center space-x-3">
+					<Switch
+						id="show-action-item"
+						checked={showActionItem}
+						onCheckedChange={(checked) =>
+							upsertSetting({ show_action_item: checked })
+						}
+					/>
+					<Label
+						htmlFor="show-action-item"
+						className="text-sm text-muted-foreground"
+					>
+						{I18n.get("show_action_item_setting")}
+					</Label>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/pages/options/src/components/index.ts
+++ b/pages/options/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from "./Header";
+export { default as MemoFieldsOption } from "./MemoFieldsOption";
 export { default as Option } from "./Option";
 export { default as QueryProvider } from "./QueryProvider";

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
@@ -1,6 +1,7 @@
 import withAuthentication from "@src/hoc/withAuthentication";
 import type { MemoInput } from "@src/types/Input";
 import { getMemoUrl } from "@src/utils";
+import { useSettingQuery } from "@web-memo/shared/hooks";
 import { I18n, Tab } from "@web-memo/shared/utils/extension";
 import {
 	Badge,
@@ -27,6 +28,7 @@ function MemoFormContent() {
 	const { ref, ...rest } = register("memo");
 
 	const currentCategoryId = watch("categoryId");
+	const { showImpression, showActionItem } = useSettingQuery();
 
 	const {
 		memoData,
@@ -140,34 +142,42 @@ function MemoFormContent() {
 						textareaRef.current = e;
 					}}
 				/>
-				<label
-					htmlFor="impression-textarea"
-					className="mt-3 text-xs font-semibold text-gray-500"
-				>
-					{I18n.get("impression")}
-				</label>
-				<Textarea
-					id="impression-textarea"
-					className="resize-none text-sm outline-none"
-					placeholder={I18n.get("impressionPlaceholder")}
-					{...register("impression", {
-						onChange: (event) => handleImpressionChange(event.target.value),
-					})}
-				/>
-				<label
-					htmlFor="action-item-textarea"
-					className="mt-3 text-xs font-semibold text-gray-500"
-				>
-					{I18n.get("actionItem")}
-				</label>
-				<Textarea
-					id="action-item-textarea"
-					className="resize-none text-sm outline-none"
-					placeholder={I18n.get("actionItemPlaceholder")}
-					{...register("actionItem", {
-						onChange: (event) => handleActionItemChange(event.target.value),
-					})}
-				/>
+				{showImpression && (
+					<>
+						<label
+							htmlFor="impression-textarea"
+							className="mt-3 text-xs font-semibold text-gray-500"
+						>
+							{I18n.get("impression")}
+						</label>
+						<Textarea
+							id="impression-textarea"
+							className="resize-none text-sm outline-none"
+							placeholder={I18n.get("impressionPlaceholder")}
+							{...register("impression", {
+								onChange: (event) => handleImpressionChange(event.target.value),
+							})}
+						/>
+					</>
+				)}
+				{showActionItem && (
+					<>
+						<label
+							htmlFor="action-item-textarea"
+							className="mt-3 text-xs font-semibold text-gray-500"
+						>
+							{I18n.get("actionItem")}
+						</label>
+						<Textarea
+							id="action-item-textarea"
+							className="resize-none text-sm outline-none"
+							placeholder={I18n.get("actionItemPlaceholder")}
+							{...register("actionItem", {
+								onChange: (event) => handleActionItemChange(event.target.value),
+							})}
+						/>
+					</>
+				)}
 				<div className="flex items-center justify-between gap-2">
 					<div className="flex items-center gap-2">
 						<HeartIcon


### PR DESCRIPTION
## 개요
느낀점/액션아이템 입력란을 사용자가 켜고 끌 수 있는 설정 추가. Supabase(`memo.setting`)에 저장해 확장프로그램·앱·웹 세 플랫폼 간 동기화.

## 작업 사항
- `memo.setting` 테이블에 `show_impression`/`show_action_item` 컬럼 및 RLS 정책 추가
- shared 패키지에 `SettingService`, `useSettingQuery`/`useSettingUpsertMutation` 훅 추가
- 웹: 설정 페이지에 토글 추가, 메모 편집 다이얼로그에서 입력란 조건부 표시
- 확장프로그램: 옵션 페이지에 토글 추가, side-panel 메모 입력란 조건부 표시
- 앱: 설정 화면에 토글 추가(로그인 시), 메모 추가/상세 편집 모달에서 입력란 조건부 표시

## 테스트
- shared/web/options/side-panel/app 5개 패키지 `type-check` 통과
- 변경 파일 전체 `biome check` 통과
