### PR TITLE
Android 키보드 가림, 값 있는 필드 토글 숨김 버그 수정

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -34,6 +34,7 @@
 				"foregroundImage": "./assets/adaptive-icon.png",
 				"backgroundColor": "#5b93f0"
 			},
+			"softwareKeyboardLayoutMode": "resize",
 			"package": "com.webmemo.app",
 			"intentFilters": [
 				{

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -68,7 +68,12 @@ export function MemoDetailModal({
 }: MemoDetailModalProps) {
 	const insets = useSafeAreaInsets();
 	const { isLoggedIn } = useAuth();
-	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
+	const {
+		showImpression: showImpressionSetting,
+		showActionItem: showActionItemSetting,
+	} = useSettingQuery(isLoggedIn);
+	const showImpression = showImpressionSetting || !!memo?.impression;
+	const showActionItem = showActionItemSetting || !!memo?.actionItem;
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);

--- a/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
+++ b/apps/web/src/app/[lng]/(auth)/memos/_components/MemoDialog/index.tsx
@@ -35,7 +35,12 @@ interface MemoDialog extends LanguageType {
 export default function MemoDialog({ lng, memoId }: MemoDialog) {
 	const { t } = useTranslation(lng);
 	const { memo: memoData } = useMemoQuery({ id: memoId });
-	const { showImpression, showActionItem } = useSettingQuery();
+	const {
+		showImpression: showImpressionSetting,
+		showActionItem: showActionItemSetting,
+	} = useSettingQuery();
+	const showImpression = showImpressionSetting || !!memoData?.impression;
+	const showActionItem = showActionItemSetting || !!memoData?.actionItem;
 	const {
 		textareaRef: memoTextareaRef,
 		handleTextareaChange: handleMemoChange,

--- a/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
+++ b/pages/side-panel/src/components/MemoSection/components/MemoForm/index.tsx
@@ -28,7 +28,10 @@ function MemoFormContent() {
 	const { ref, ...rest } = register("memo");
 
 	const currentCategoryId = watch("categoryId");
-	const { showImpression, showActionItem } = useSettingQuery();
+	const {
+		showImpression: showImpressionSetting,
+		showActionItem: showActionItemSetting,
+	} = useSettingQuery();
 
 	const {
 		memoData,
@@ -40,6 +43,9 @@ function MemoFormContent() {
 		toggleWish,
 		toggleStar,
 	} = useMemoForm();
+
+	const showImpression = showImpressionSetting || !!memoData?.impression;
+	const showActionItem = showActionItemSetting || !!memoData?.actionItem;
 
 	const {
 		categories,


### PR DESCRIPTION
## 개요
Android 키보드가 입력창을 가리는 문제, 느낀점/액션아이템 토글이 꺼져 있을 때 이미 저장된 값이 편집 화면에서 안 보이던 문제 수정.

## 작업 사항
- `app.json`에 `android.softwareKeyboardLayoutMode: "resize"` 추가 — Android에서 키보드가 뜰 때 화면이 리사이즈되도록 처리
- 웹 `MemoDialog`, 앱 `MemoDetailModal`, 확장프로그램 side-panel `MemoForm`에서 느낀점/액션아이템 값이 이미 존재하면 표시 토글이 꺼져 있어도 편집 필드를 노출

## 테스트
- web/app/side-panel `type-check` 통과
- 변경 파일 `biome check` 통과
