### PR TITLE
앱 메모 화면 다크모드 지원

### DIFF
--- a/apps/app/app/(main)/_components/AddMemoModal.tsx
+++ b/apps/app/app/(main)/_components/AddMemoModal.tsx
@@ -9,6 +9,7 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -36,6 +37,7 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 	const insets = useSafeAreaInsets();
 	const { isLoggedIn } = useAuth();
 	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
+	const isDark = useColorScheme() === "dark";
 
 	const [titleText, setTitleText] = useState("");
 	const [urlText, setUrlText] = useState("");
@@ -129,16 +131,16 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 				behavior={Platform.OS === "ios" ? "padding" : undefined}
 			>
 				<View
-					className="bg-white rounded-t-[20px] overflow-hidden"
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px] overflow-hidden"
 					style={{ height: "85%", paddingBottom: insets.bottom }}
 				>
-					<View className="flex-row items-center justify-between px-5 pt-4 pb-3 border-b border-border">
-						<Text className="text-base font-semibold text-foreground">
+					<View className="flex-row items-center justify-between px-5 pt-4 pb-3 border-b border-border dark:border-neutral-800">
+						<Text className="text-base font-semibold text-foreground dark:text-white">
 							메모 추가
 						</Text>
 						<View className="flex-row items-center gap-2">
 							<TouchableOpacity
-								className={`flex-row items-center gap-1.5 px-3.5 py-2 rounded-lg ${hasContent ? "bg-foreground" : "bg-muted"}`}
+								className={`flex-row items-center gap-1.5 px-3.5 py-2 rounded-lg ${hasContent ? "bg-foreground" : "bg-muted dark:bg-neutral-700"}`}
 								onPress={handleSave}
 								disabled={!hasContent || isSaving}
 								activeOpacity={0.8}
@@ -146,16 +148,19 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 								{isSaving ? (
 									<ActivityIndicator size="small" color="#fff" />
 								) : (
-									<Save size={16} color={hasContent ? "#fff" : "#999"} />
+									<Save
+										size={16}
+										color={hasContent ? "#fff" : isDark ? "#666" : "#999"}
+									/>
 								)}
 								<Text
-									className={`text-sm font-semibold ${hasContent ? "text-white" : "text-gray-400"}`}
+									className={`text-sm font-semibold ${hasContent ? "text-white" : "text-gray-400 dark:text-neutral-500"}`}
 								>
 									저장
 								</Text>
 							</TouchableOpacity>
 							<TouchableOpacity onPress={handleClose} activeOpacity={0.7}>
-								<X size={22} color="#666" />
+								<X size={22} color={isDark ? "#aaa" : "#666"} />
 							</TouchableOpacity>
 						</View>
 					</View>
@@ -167,37 +172,40 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 						contentContainerStyle={{ paddingTop: 16, paddingBottom: 24 }}
 						showsVerticalScrollIndicator={false}
 					>
-						<View className="flex-row items-center bg-input rounded-[10px] px-3 py-2.5 gap-2">
-							<Type size={16} color="#999" />
+						<View className="flex-row items-center bg-input dark:bg-neutral-800 rounded-[10px] px-3 py-2.5 gap-2">
+							<Type size={16} color={isDark ? "#777" : "#999"} />
 							<TextInput
-								className="flex-1 text-sm text-[#333] p-0"
+								className="flex-1 text-sm text-[#333] dark:text-white p-0"
 								value={titleText}
 								onChangeText={setTitleText}
 								placeholder="제목 (선택)"
+								placeholderTextColor={isDark ? "#666" : "#999"}
 								returnKeyType="next"
 							/>
 						</View>
 
-						<View className="flex-row items-center bg-input rounded-[10px] px-3 py-2.5 gap-2 mt-2">
-							<Link2 size={16} color="#999" />
+						<View className="flex-row items-center bg-input dark:bg-neutral-800 rounded-[10px] px-3 py-2.5 gap-2 mt-2">
+							<Link2 size={16} color={isDark ? "#777" : "#999"} />
 							<TextInput
-								className="flex-1 text-sm text-[#333] p-0"
+								className="flex-1 text-sm text-[#333] dark:text-white p-0"
 								value={urlText}
 								onChangeText={setUrlText}
 								placeholder="URL (선택)"
+								placeholderTextColor={isDark ? "#666" : "#999"}
 								autoCapitalize="none"
 								autoCorrect={false}
 								keyboardType="url"
 								returnKeyType="next"
 							/>
 						</View>
-						<Text className="mt-1.5 text-xs text-gray-400">
+						<Text className="mt-1.5 text-xs text-gray-400 dark:text-neutral-500">
 							URL을 입력하면 제목과 아이콘을 자동으로 가져옵니다
 						</Text>
 
 						<TextInput
-							className="min-h-[140px] mt-4 text-[15px] text-[#333] leading-[22px]"
+							className="min-h-[140px] mt-4 text-[15px] text-[#333] dark:text-white leading-[22px]"
 							placeholder="메모를 작성하세요..."
+							placeholderTextColor={isDark ? "#666" : "#999"}
 							value={memoText}
 							onChangeText={setMemoText}
 							multiline
@@ -207,12 +215,13 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 
 						{showImpression && (
 							<>
-								<Text className="mt-3 text-xs font-semibold text-gray-500">
+								<Text className="mt-3 text-xs font-semibold text-gray-500 dark:text-neutral-400">
 									느낀 점
 								</Text>
 								<TextInput
-									className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+									className="min-h-[60px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 									placeholder="느낀 점을 적어보세요"
+									placeholderTextColor={isDark ? "#666" : "#999"}
 									value={impressionText}
 									onChangeText={setImpressionText}
 									multiline
@@ -224,12 +233,13 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 
 						{showActionItem && (
 							<>
-								<Text className="mt-3 text-xs font-semibold text-gray-500">
+								<Text className="mt-3 text-xs font-semibold text-gray-500 dark:text-neutral-400">
 									액션 아이템
 								</Text>
 								<TextInput
-									className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+									className="min-h-[60px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 									placeholder="할 일을 적어보세요"
+									placeholderTextColor={isDark ? "#666" : "#999"}
 									value={actionItemText}
 									onChangeText={setActionItemText}
 									multiline

--- a/apps/app/app/(main)/_components/MemoCard.tsx
+++ b/apps/app/app/(main)/_components/MemoCard.tsx
@@ -1,7 +1,13 @@
 import type { GetMemoResponse } from "@web-memo/shared/types";
 import { BookOpen, FileText, Heart, Star, Trash2 } from "lucide-react-native";
 import { useRef } from "react";
-import { Image, Text, TouchableOpacity, View } from "react-native";
+import {
+	Image,
+	Text,
+	TouchableOpacity,
+	useColorScheme,
+	View,
+} from "react-native";
 import ReanimatedSwipeable, {
 	type SwipeableMethods,
 } from "react-native-gesture-handler/ReanimatedSwipeable";
@@ -43,6 +49,7 @@ export function MemoCard({
 	onDelete,
 }: MemoCardProps) {
 	const swipeableRef = useRef<SwipeableMethods>(null);
+	const isDark = useColorScheme() === "dark";
 
 	const rawDate =
 		"updated_at" in memo
@@ -68,7 +75,7 @@ export function MemoCard({
 			rightThreshold={40}
 		>
 			<TouchableOpacity
-				className="bg-card rounded-xl p-3.5 mb-2.5 border border-muted"
+				className="bg-card dark:bg-neutral-900 rounded-xl p-3.5 mb-2.5 border border-muted dark:border-neutral-800"
 				onPress={onPress}
 				activeOpacity={0.7}
 			>
@@ -79,24 +86,26 @@ export function MemoCard({
 							style={{ width: 14, height: 14, borderRadius: 2 }}
 						/>
 					) : (
-						<FileText size={14} color="#666" />
+						<FileText size={14} color={isDark ? "#aaa" : "#666"} />
 					)}
 					<Text
-						className="flex-1 text-[15px] font-semibold text-foreground"
+						className="flex-1 text-[15px] font-semibold text-foreground dark:text-white"
 						numberOfLines={1}
 					>
 						{memo.title}
 					</Text>
 					{typeof readingProgress === "number" ? (
-						<View className="flex-row items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-violet-100">
-							<BookOpen size={10} color="#7c3aed" />
-							<Text className="text-[10px] font-semibold text-[#7c3aed]">
+						<View className="flex-row items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-violet-100 dark:bg-violet-900/40">
+							<BookOpen size={10} color={isDark ? "#c4b5fd" : "#7c3aed"} />
+							<Text className="text-[10px] font-semibold text-[#7c3aed] dark:text-violet-300">
 								읽는 중 {Math.round(readingProgress * 100)}%
 							</Text>
 						</View>
 					) : null}
 					{dateLabel ? (
-						<Text className="text-xs text-muted-foreground">{dateLabel}</Text>
+						<Text className="text-xs text-muted-foreground dark:text-neutral-500">
+							{dateLabel}
+						</Text>
 					) : null}
 					{memo.isReading && <BookOpen size={12} color="#10b981" />}
 					{memo.isWish && <Heart size={12} fill="#ec4899" color="#ec4899" />}
@@ -106,7 +115,7 @@ export function MemoCard({
 				</View>
 				{memo.memo && (
 					<Text
-						className="text-sm text-secondary-foreground leading-5 mb-1.5"
+						className="text-sm text-secondary-foreground dark:text-neutral-300 leading-5 mb-1.5"
 						numberOfLines={10}
 					>
 						{memo.memo}
@@ -114,7 +123,7 @@ export function MemoCard({
 				)}
 				{memo.impression ? (
 					<Text
-						className="text-sm text-secondary-foreground leading-5 mb-1.5"
+						className="text-sm text-secondary-foreground dark:text-neutral-300 leading-5 mb-1.5"
 						numberOfLines={4}
 					>
 						느낀 점: {memo.impression}
@@ -122,7 +131,7 @@ export function MemoCard({
 				) : null}
 				{memo.actionItem ? (
 					<Text
-						className="text-sm text-secondary-foreground leading-5 mb-1.5"
+						className="text-sm text-secondary-foreground dark:text-neutral-300 leading-5 mb-1.5"
 						numberOfLines={4}
 					>
 						액션 아이템: {memo.actionItem}

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -23,6 +23,7 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -74,6 +75,7 @@ export function MemoDetailModal({
 	} = useSettingQuery(isLoggedIn);
 	const showImpression = showImpressionSetting || !!memo?.impression;
 	const showActionItem = showActionItemSetting || !!memo?.actionItem;
+	const isDark = useColorScheme() === "dark";
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
@@ -215,14 +217,14 @@ export function MemoDetailModal({
 				</Animated.View>
 
 				<Animated.View
-					className="bg-white rounded-t-[20px]"
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
 					style={[
 						sheetStyle,
 						{ height: SHEET_HEIGHT, paddingBottom: insets.bottom + 16 },
 					]}
 				>
 					<View className="items-center py-2.5">
-						<View className="w-9 h-1 rounded-sm bg-gray-300" />
+						<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
 					</View>
 
 					<View className="flex-row items-center justify-between px-5 pb-3 gap-2">
@@ -232,14 +234,15 @@ export function MemoDetailModal({
 								style={{ width: 14, height: 14, borderRadius: 2 }}
 							/>
 						) : (
-							<FileText size={14} color="#666" />
+							<FileText size={14} color={isDark ? "#aaa" : "#666"} />
 						)}
 						{isEditing ? (
 							<TextInput
-								className="flex-1 p-0 text-base font-semibold text-foreground"
+								className="flex-1 p-0 text-base font-semibold text-foreground dark:text-white"
 								value={editedTitle}
 								onChangeText={setEditedTitle}
 								placeholder="제목을 입력하세요"
+								placeholderTextColor={isDark ? "#666" : "#999"}
 							/>
 						) : isWebUrl ? (
 							<TouchableOpacity
@@ -248,7 +251,7 @@ export function MemoDetailModal({
 								activeOpacity={0.7}
 							>
 								<Text
-									className="text-base font-semibold text-foreground"
+									className="text-base font-semibold text-foreground dark:text-white"
 									numberOfLines={1}
 								>
 									{title}
@@ -257,7 +260,7 @@ export function MemoDetailModal({
 						) : (
 							<View className="flex-1">
 								<Text
-									className="text-base font-semibold text-foreground"
+									className="text-base font-semibold text-foreground dark:text-white"
 									numberOfLines={1}
 								>
 									{title}
@@ -271,19 +274,22 @@ export function MemoDetailModal({
 									onPress={handleCancelEdit}
 									activeOpacity={0.7}
 								>
-									<Text className="text-sm font-medium text-muted-foreground">
+									<Text className="text-sm font-medium text-muted-foreground dark:text-neutral-400">
 										취소
 									</Text>
 								</TouchableOpacity>
 								<TouchableOpacity
-									className={`flex-row items-center gap-1 px-3 py-1.5 rounded-lg ${isMemoEdited ? "bg-foreground" : "bg-muted"}`}
+									className={`flex-row items-center gap-1 px-3 py-1.5 rounded-lg ${isMemoEdited ? "bg-foreground" : "bg-muted dark:bg-neutral-700"}`}
 									onPress={handleSaveMemo}
 									disabled={!isMemoEdited}
 									activeOpacity={0.7}
 								>
-									<Save size={14} color={isMemoEdited ? "#fff" : "#999"} />
+									<Save
+										size={14}
+										color={isMemoEdited ? "#fff" : isDark ? "#666" : "#999"}
+									/>
 									<Text
-										className={`text-sm font-semibold ${isMemoEdited ? "text-white" : "text-gray-400"}`}
+										className={`text-sm font-semibold ${isMemoEdited ? "text-white" : "text-gray-400 dark:text-neutral-500"}`}
 									>
 										저장
 									</Text>
@@ -299,7 +305,7 @@ export function MemoDetailModal({
 										{saved ? (
 											<Check size={20} color="#22c55e" />
 										) : (
-											<Pencil size={18} color="#666" />
+											<Pencil size={18} color={isDark ? "#aaa" : "#666"} />
 										)}
 									</TouchableOpacity>
 								) : null}
@@ -325,11 +331,11 @@ export function MemoDetailModal({
 								)}
 								{isWebUrl && (
 									<TouchableOpacity onPress={handleShare} activeOpacity={0.7}>
-										<Share2 size={20} color="#666" />
+										<Share2 size={20} color={isDark ? "#aaa" : "#666"} />
 									</TouchableOpacity>
 								)}
 								<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
-									<X size={22} color="#666" />
+									<X size={22} color={isDark ? "#aaa" : "#666"} />
 								</TouchableOpacity>
 							</>
 						)}
@@ -343,10 +349,11 @@ export function MemoDetailModal({
 							showsVerticalScrollIndicator={false}
 						>
 							<TextInput
-								className="min-h-[80px] text-[15px] text-[#333] leading-[22px]"
+								className="min-h-[80px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 								value={editedMemo}
 								onChangeText={setEditedMemo}
 								placeholder="메모를 입력하세요..."
+								placeholderTextColor={isDark ? "#666" : "#999"}
 								multiline
 								textAlignVertical="top"
 								scrollEnabled={false}
@@ -354,14 +361,15 @@ export function MemoDetailModal({
 							/>
 							{showImpression && (
 								<>
-									<Text className="mt-3 text-xs font-semibold text-gray-500">
+									<Text className="mt-3 text-xs font-semibold text-gray-500 dark:text-neutral-400">
 										느낀 점
 									</Text>
 									<TextInput
-										className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
+										className="min-h-[48px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 										value={editedImpression}
 										onChangeText={setEditedImpression}
 										placeholder="이 페이지에서 느낀 점을 적어보세요"
+										placeholderTextColor={isDark ? "#666" : "#999"}
 										multiline
 										textAlignVertical="top"
 										scrollEnabled={false}
@@ -370,14 +378,15 @@ export function MemoDetailModal({
 							)}
 							{showActionItem && (
 								<>
-									<Text className="mt-3 text-xs font-semibold text-gray-500">
+									<Text className="mt-3 text-xs font-semibold text-gray-500 dark:text-neutral-400">
 										액션 아이템
 									</Text>
 									<TextInput
-										className="min-h-[48px] text-[15px] text-[#333] leading-[22px]"
+										className="min-h-[48px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 										value={editedActionItem}
 										onChangeText={setEditedActionItem}
 										placeholder="이 페이지를 보고 할 일을 적어보세요"
+										placeholderTextColor={isDark ? "#666" : "#999"}
 										multiline
 										textAlignVertical="top"
 										scrollEnabled={false}
@@ -392,30 +401,30 @@ export function MemoDetailModal({
 							showsVerticalScrollIndicator={false}
 						>
 							{memoText ? (
-								<Text className="text-[15px] text-[#333] leading-[22px]">
+								<Text className="text-[15px] text-[#333] dark:text-white leading-[22px]">
 									{memoText}
 								</Text>
 							) : (
-								<Text className="text-[15px] text-gray-400 leading-[22px]">
+								<Text className="text-[15px] text-gray-400 dark:text-neutral-500 leading-[22px]">
 									메모가 없습니다. 연필 아이콘을 눌러 작성하세요.
 								</Text>
 							)}
 							{memo?.impression ? (
 								<View className="mt-3">
-									<Text className="text-xs font-semibold text-gray-500 mb-1">
+									<Text className="text-xs font-semibold text-gray-500 dark:text-neutral-400 mb-1">
 										느낀 점
 									</Text>
-									<Text className="text-[15px] text-[#333] leading-[22px]">
+									<Text className="text-[15px] text-[#333] dark:text-white leading-[22px]">
 										{memo.impression}
 									</Text>
 								</View>
 							) : null}
 							{memo?.actionItem ? (
 								<View className="mt-3">
-									<Text className="text-xs font-semibold text-gray-500 mb-1">
+									<Text className="text-xs font-semibold text-gray-500 dark:text-neutral-400 mb-1">
 										액션 아이템
 									</Text>
-									<Text className="text-[15px] text-[#333] leading-[22px]">
+									<Text className="text-[15px] text-[#333] dark:text-white leading-[22px]">
 										{memo.actionItem}
 									</Text>
 								</View>
@@ -428,14 +437,14 @@ export function MemoDetailModal({
 							<View className="flex-row items-center gap-2">
 								{domain ? (
 									<View className="flex-row items-center gap-1">
-										<Globe size={11} color="#999" />
-										<Text className="text-xs text-muted-foreground">
+										<Globe size={11} color={isDark ? "#777" : "#999"} />
+										<Text className="text-xs text-muted-foreground dark:text-neutral-500">
 											{domain}
 										</Text>
 									</View>
 								) : null}
 								{formattedDate ? (
-									<Text className="text-xs text-muted-foreground">
+									<Text className="text-xs text-muted-foreground dark:text-neutral-500">
 										{formattedDate}
 									</Text>
 								) : null}

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -9,6 +9,7 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useAuth } from "@/lib/auth/AuthProvider";
@@ -33,6 +34,7 @@ export function MemoPanel({
 	onClose,
 }: MemoPanelProps) {
 	const { isLoggedIn } = useAuth();
+	const isDark = useColorScheme() === "dark";
 
 	const [titleText, setTitleText] = useState("");
 	const [memoText, setMemoText] = useState("");
@@ -146,7 +148,7 @@ export function MemoPanel({
 	};
 
 	return (
-		<View className="flex-1 bg-white p-3">
+		<View className="flex-1 bg-white dark:bg-neutral-900 p-3">
 			<View className="flex-row justify-between items-center mb-2">
 				<View className="flex-row items-center gap-1.5 flex-1 mr-2">
 					{favIconUrl ? (
@@ -155,23 +157,24 @@ export function MemoPanel({
 							style={{ width: 14, height: 14, borderRadius: 2 }}
 						/>
 					) : (
-						<FileText size={14} color="#666" />
+						<FileText size={14} color={isDark ? "#aaa" : "#666"} />
 					)}
 					<TextInput
-						className="flex-1 text-base font-semibold text-foreground p-0"
+						className="flex-1 text-base font-semibold text-foreground dark:text-white p-0"
 						value={titleText}
 						onChangeText={setTitleText}
 						placeholder="제목"
+						placeholderTextColor={isDark ? "#666" : "#999"}
 						numberOfLines={1}
 					/>
 				</View>
 				<View className="flex-row items-center gap-2">
 					{isKeyboardVisible && (
 						<TouchableOpacity
-							className="items-center justify-center bg-muted px-2.5 py-2 rounded-lg"
+							className="items-center justify-center bg-muted dark:bg-neutral-700 px-2.5 py-2 rounded-lg"
 							onPress={() => Keyboard.dismiss()}
 						>
-							<ChevronDown size={16} color="#666" />
+							<ChevronDown size={16} color={isDark ? "#aaa" : "#666"} />
 						</TouchableOpacity>
 					)}
 					{onClose && (
@@ -179,7 +182,7 @@ export function MemoPanel({
 							className="items-center justify-center p-1.5"
 							onPress={onClose}
 						>
-							<X size={16} color="#999" />
+							<X size={16} color={isDark ? "#777" : "#999"} />
 						</TouchableOpacity>
 					)}
 					<TouchableOpacity
@@ -214,8 +217,9 @@ export function MemoPanel({
 				showsVerticalScrollIndicator={false}
 			>
 				<TextInput
-					className="min-h-[140px] text-[15px] text-[#333] leading-[22px]"
+					className="min-h-[140px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 					placeholder="이 페이지에 대한 메모를 작성하세요..."
+					placeholderTextColor={isDark ? "#666" : "#999"}
 					value={memoText}
 					onChangeText={setMemoText}
 					multiline
@@ -223,12 +227,13 @@ export function MemoPanel({
 					textAlignVertical="top"
 				/>
 
-				<Text className="mt-3 text-xs font-semibold text-gray-500">
+				<Text className="mt-3 text-xs font-semibold text-gray-500 dark:text-neutral-400">
 					느낀 점
 				</Text>
 				<TextInput
-					className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+					className="min-h-[60px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 					placeholder="이 페이지에서 느낀 점을 적어보세요"
+					placeholderTextColor={isDark ? "#666" : "#999"}
 					value={impressionText}
 					onChangeText={setImpressionText}
 					multiline
@@ -236,12 +241,13 @@ export function MemoPanel({
 					textAlignVertical="top"
 				/>
 
-				<Text className="mt-3 text-xs font-semibold text-gray-500">
+				<Text className="mt-3 text-xs font-semibold text-gray-500 dark:text-neutral-400">
 					액션 아이템
 				</Text>
 				<TextInput
-					className="min-h-[60px] text-[15px] text-[#333] leading-[22px]"
+					className="min-h-[60px] text-[15px] text-[#333] dark:text-white leading-[22px]"
 					placeholder="이 페이지를 보고 할 일을 적어보세요"
+					placeholderTextColor={isDark ? "#666" : "#999"}
 					value={actionItemText}
 					onChangeText={setActionItemText}
 					multiline


### PR DESCRIPTION
## 개요
앱의 메모 관련 화면(브라우저 메모 패널, 메모 추가/상세 모달, 메모 카드)에 다크모드 지원 추가. 시스템 다크모드 설정을 자동으로 따름.

## 작업 사항
- `MemoPanel`, `AddMemoModal`, `MemoDetailModal`, `MemoCard`에 `dark:` 배경/텍스트/테두리 클래스 추가
- lucide 아이콘은 className을 지원하지 않아 `useColorScheme`으로 조건부 색상 처리
- 별도 토글 없이 OS 다크모드 설정을 그대로 반영(NativeWind 기본 media 전략)

## 테스트
- `@web-memo/app` type-check 통과
- 변경 파일 `biome check` 통과
