### PR TITLE
브라우저 액션 통합, 드래그 메모, AI 요약/질의응답

### DIFF
--- a/apps/app/app/(main)/browser/_components/AISheet.tsx
+++ b/apps/app/app/(main)/browser/_components/AISheet.tsx
@@ -1,0 +1,195 @@
+import { Send, Sparkles, X } from "lucide-react-native";
+import { useEffect, useState } from "react";
+import {
+	ActivityIndicator,
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	Pressable,
+	ScrollView,
+	Text,
+	TextInput,
+	TouchableOpacity,
+	useColorScheme,
+	View,
+} from "react-native";
+import Animated, {
+	useAnimatedStyle,
+	useSharedValue,
+	withTiming,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const SHEET_ANIMATION_DISTANCE = 600;
+
+interface AISheetProps {
+	visible: boolean;
+	onClose: () => void;
+	summary: string | null;
+	answer: string | null;
+	question: string;
+	onQuestionChange: (text: string) => void;
+	onAskQuestion: () => void;
+	isLoading: boolean;
+	error: string | null;
+}
+
+/** 현재 보고 있는 페이지 본문을 요약하고, 이어서 질문할 수 있는 시트 */
+export function AISheet({
+	visible,
+	onClose,
+	summary,
+	answer,
+	question,
+	onQuestionChange,
+	onAskQuestion,
+	isLoading,
+	error,
+}: AISheetProps) {
+	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
+	const translateY = useSharedValue(SHEET_ANIMATION_DISTANCE);
+	const opacity = useSharedValue(0);
+	const [modalVisible, setModalVisible] = useState(false);
+
+	useEffect(() => {
+		if (visible) {
+			setModalVisible(true);
+			translateY.value = withTiming(0, { duration: 280 });
+			opacity.value = withTiming(1, { duration: 280 });
+		} else {
+			translateY.value = withTiming(SHEET_ANIMATION_DISTANCE, {
+				duration: 220,
+			});
+			opacity.value = withTiming(0, { duration: 220 });
+			const timer = setTimeout(() => setModalVisible(false), 230);
+			return () => clearTimeout(timer);
+		}
+	}, [visible, translateY, opacity]);
+
+	const sheetStyle = useAnimatedStyle(() => ({
+		transform: [{ translateY: translateY.value }],
+	}));
+
+	const overlayStyle = useAnimatedStyle(() => ({
+		opacity: opacity.value,
+	}));
+
+	return (
+		<Modal visible={modalVisible} transparent statusBarTranslucent>
+			<KeyboardAvoidingView
+				className="flex-1 justify-end"
+				behavior={Platform.OS === "ios" ? "padding" : undefined}
+			>
+				<Animated.View
+					className="absolute inset-0 bg-black/40"
+					style={overlayStyle}
+				>
+					<Pressable className="absolute inset-0" onPress={onClose} />
+				</Animated.View>
+
+				<Animated.View
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
+					style={[
+						sheetStyle,
+						{ height: "75%", paddingBottom: insets.bottom + 12 },
+					]}
+				>
+					<View className="items-center py-2.5">
+						<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
+					</View>
+
+					<View className="flex-row justify-between items-center px-5 pb-3">
+						<View className="flex-row items-center gap-1.5">
+							<Sparkles size={18} color="#7c3aed" />
+							<Text className="text-lg font-bold text-foreground dark:text-white">
+								AI 요약/질문
+							</Text>
+						</View>
+						<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
+							<X size={22} color={isDark ? "#aaa" : "#666"} />
+						</TouchableOpacity>
+					</View>
+
+					<ScrollView
+						className="flex-1 px-5"
+						contentContainerStyle={{ paddingBottom: 16 }}
+						showsVerticalScrollIndicator={false}
+					>
+						{isLoading && !summary && !answer ? (
+							<View className="items-center py-10 gap-2">
+								<ActivityIndicator size="small" color="#7c3aed" />
+								<Text className="text-sm text-muted-foreground dark:text-neutral-500">
+									페이지를 읽고 요약하는 중이에요...
+								</Text>
+							</View>
+						) : error ? (
+							<Text className="text-sm text-destructive">{error}</Text>
+						) : (
+							<>
+								{summary ? (
+									<View className="mb-4">
+										<Text className="text-xs font-semibold text-gray-500 dark:text-neutral-400 mb-1.5">
+											요약
+										</Text>
+										<Text className="text-[15px] text-[#333] dark:text-white leading-[22px]">
+											{summary}
+										</Text>
+									</View>
+								) : null}
+
+								{question ? (
+									<View className="mb-2">
+										<Text className="text-xs font-semibold text-gray-500 dark:text-neutral-400 mb-1.5">
+											질문
+										</Text>
+										<Text className="text-[15px] text-[#333] dark:text-white leading-[22px]">
+											{question}
+										</Text>
+									</View>
+								) : null}
+
+								{isLoading && summary ? (
+									<ActivityIndicator
+										size="small"
+										color="#7c3aed"
+										style={{ marginTop: 8 }}
+									/>
+								) : answer ? (
+									<View className="mt-1">
+										<Text className="text-xs font-semibold text-gray-500 dark:text-neutral-400 mb-1.5">
+											답변
+										</Text>
+										<Text className="text-[15px] text-[#333] dark:text-white leading-[22px]">
+											{answer}
+										</Text>
+									</View>
+								) : null}
+							</>
+						)}
+					</ScrollView>
+
+					<View className="flex-row items-center gap-2 px-5 pt-2">
+						<TextInput
+							className="flex-1 bg-input dark:bg-neutral-800 rounded-[10px] px-3 py-2.5 text-sm text-[#333] dark:text-white"
+							value={question}
+							onChangeText={onQuestionChange}
+							placeholder="이 페이지에 대해 질문해보세요"
+							placeholderTextColor={isDark ? "#666" : "#999"}
+							returnKeyType="send"
+							onSubmitEditing={onAskQuestion}
+							editable={!isLoading}
+						/>
+						<TouchableOpacity
+							className="bg-foreground p-2.5 rounded-[10px]"
+							onPress={onAskQuestion}
+							disabled={isLoading || !question.trim()}
+						>
+							<Send size={16} color="#fff" />
+						</TouchableOpacity>
+					</View>
+				</Animated.View>
+			</KeyboardAvoidingView>
+		</Modal>
+	);
+}

--- a/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
+++ b/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
@@ -1,15 +1,17 @@
 import {
-	Bookmark,
-	BookOpen,
-	Heart,
 	Home,
 	LayoutGrid,
+	MoreHorizontal,
 	RotateCw,
 	Search,
-	Share2,
 	X,
 } from "lucide-react-native";
-import { TextInput, TouchableOpacity, View } from "react-native";
+import {
+	TextInput,
+	TouchableOpacity,
+	useColorScheme,
+	View,
+} from "react-native";
 import Animated from "react-native-reanimated";
 import type WebView from "react-native-webview";
 
@@ -18,50 +20,43 @@ type AnimatedViewStyle = React.ComponentProps<typeof Animated.View>["style"];
 interface BrowserHeaderProps {
 	urlInput: string;
 	currentUrl: string;
-	isCurrentPageWish: boolean;
-	isCurrentPageReading: boolean;
-	isCurrentPageFavorite: boolean;
+	hasActiveStatus: boolean;
 	headerWrapperStyle: AnimatedViewStyle;
 	webViewRef: React.RefObject<WebView | null>;
 	onUrlInputChange: (text: string) => void;
 	onUrlSubmit: () => void;
 	onGoHome: () => void;
 	onOpenBlogSheet: () => void;
-	onFavoriteToggle: () => void;
-	onReadingToggle: () => void;
-	onWishToggle: () => void;
-	onShare: () => void;
+	onOpenActions: () => void;
 }
 
 export function BrowserHeader({
 	urlInput,
 	currentUrl,
-	isCurrentPageWish,
-	isCurrentPageReading,
-	isCurrentPageFavorite,
+	hasActiveStatus,
 	headerWrapperStyle,
 	webViewRef,
 	onUrlInputChange,
 	onUrlSubmit,
 	onGoHome,
 	onOpenBlogSheet,
-	onFavoriteToggle,
-	onReadingToggle,
-	onWishToggle,
-	onShare,
+	onOpenActions,
 }: BrowserHeaderProps) {
+	const isDark = useColorScheme() === "dark";
+
 	return (
 		<Animated.View className="overflow-hidden" style={headerWrapperStyle}>
-			<View className="flex-row items-center px-1.5 py-1.5 gap-0.5 border-b border-border bg-white">
-				<View className="flex-1 flex-row items-center bg-input rounded-[10px] px-2.5 py-2 gap-1.5">
-					<Search size={14} color="#999" />
+			<View className="flex-row items-center px-1.5 py-1.5 gap-0.5 border-b border-border dark:border-neutral-800 bg-white dark:bg-neutral-900">
+				<View className="flex-1 flex-row items-center bg-input dark:bg-neutral-800 rounded-[10px] px-2.5 py-2 gap-1.5">
+					<Search size={14} color={isDark ? "#777" : "#999"} />
 					<TextInput
-						className="flex-1 text-sm text-[#333] p-0"
+						className="flex-1 text-sm text-[#333] dark:text-white p-0"
 						value={urlInput}
 						onChangeText={onUrlInputChange}
 						onFocus={() => onUrlInputChange(currentUrl)}
 						onSubmitEditing={onUrlSubmit}
 						placeholder="Search or enter URL"
+						placeholderTextColor={isDark ? "#666" : "#999"}
 						autoCapitalize="none"
 						autoCorrect={false}
 						keyboardType="url"
@@ -70,44 +65,29 @@ export function BrowserHeader({
 					/>
 					{urlInput.length > 0 && (
 						<TouchableOpacity onPress={() => onUrlInputChange("")} hitSlop={8}>
-							<X size={14} color="#999" />
+							<X size={14} color={isDark ? "#777" : "#999"} />
 						</TouchableOpacity>
 					)}
 				</View>
-				<TouchableOpacity onPress={onShare} className="p-1.5">
-					<Share2 size={16} color="#111" />
-				</TouchableOpacity>
 				<TouchableOpacity
 					onPress={() => webViewRef.current?.reload()}
 					className="p-1.5"
 				>
-					<RotateCw size={16} color="#111" />
+					<RotateCw size={16} color={isDark ? "#eee" : "#111"} />
 				</TouchableOpacity>
 				<TouchableOpacity onPress={onGoHome} className="p-1.5">
-					<Home size={16} color="#111" />
+					<Home size={16} color={isDark ? "#eee" : "#111"} />
 				</TouchableOpacity>
 				<TouchableOpacity onPress={onOpenBlogSheet} className="p-1.5">
-					<LayoutGrid size={16} color="#111" />
+					<LayoutGrid size={16} color={isDark ? "#eee" : "#111"} />
 				</TouchableOpacity>
-				<TouchableOpacity onPress={onFavoriteToggle} className="p-1.5">
-					<Bookmark
-						size={16}
-						color={isCurrentPageFavorite ? "#f59e0b" : "#111"}
-						fill={isCurrentPageFavorite ? "#f59e0b" : "none"}
-					/>
-				</TouchableOpacity>
-				<TouchableOpacity onPress={onReadingToggle} className="p-1.5">
-					<BookOpen
-						size={16}
-						color={isCurrentPageReading ? "#10b981" : "#111"}
-					/>
-				</TouchableOpacity>
-				<TouchableOpacity onPress={onWishToggle} className="p-1.5">
-					<Heart
-						size={16}
-						color={isCurrentPageWish ? "#ec4899" : "#111"}
-						fill={isCurrentPageWish ? "#ec4899" : "none"}
-					/>
+				<TouchableOpacity onPress={onOpenActions} className="p-1.5">
+					<View>
+						<MoreHorizontal size={16} color={isDark ? "#eee" : "#111"} />
+						{hasActiveStatus && (
+							<View className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-[#f59e0b]" />
+						)}
+					</View>
 				</TouchableOpacity>
 			</View>
 		</Animated.View>

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -25,6 +25,9 @@ interface MemoPanelProps {
 	pageTitle: string;
 	favIconUrl?: string;
 	onClose?: () => void;
+	/** 웹뷰에서 드래그로 선택된 텍스트. 값이 바뀔 때마다 메모에 자동으로 덧붙인다 */
+	selectedText?: string | null;
+	onSelectedTextConsumed?: () => void;
 }
 
 export function MemoPanel({
@@ -32,6 +35,8 @@ export function MemoPanel({
 	pageTitle,
 	favIconUrl,
 	onClose,
+	selectedText,
+	onSelectedTextConsumed,
 }: MemoPanelProps) {
 	const { isLoggedIn } = useAuth();
 	const isDark = useColorScheme() === "dark";
@@ -110,6 +115,12 @@ export function MemoPanel({
 		pageTitle,
 		url,
 	]);
+
+	useEffect(() => {
+		if (!selectedText) return;
+		setMemoText((prev) => (prev ? `${prev}\n${selectedText}` : selectedText));
+		onSelectedTextConsumed?.();
+	}, [selectedText, onSelectedTextConsumed]);
 
 	const onSaveSuccess = () => {
 		justSavedRef.current = true;

--- a/apps/app/app/(main)/browser/_components/PageActionsSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/PageActionsSheet.tsx
@@ -1,0 +1,201 @@
+import {
+	Bookmark,
+	BookOpen,
+	Heart,
+	Share2,
+	Sparkles,
+	Star,
+	X,
+} from "lucide-react-native";
+import { useEffect, useState } from "react";
+import {
+	Modal,
+	Pressable,
+	Text,
+	TouchableOpacity,
+	useColorScheme,
+	View,
+} from "react-native";
+import Animated, {
+	useAnimatedStyle,
+	useSharedValue,
+	withTiming,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const SHEET_ANIMATION_DISTANCE = 400;
+
+interface ActionRowProps {
+	icon: React.ReactNode;
+	label: string;
+	onPress: () => void;
+}
+
+function ActionRow({ icon, label, onPress }: ActionRowProps) {
+	return (
+		<TouchableOpacity
+			className="flex-row items-center gap-3 px-5 py-3.5"
+			onPress={onPress}
+			activeOpacity={0.6}
+		>
+			{icon}
+			<Text className="text-[15px] text-foreground dark:text-white">
+				{label}
+			</Text>
+		</TouchableOpacity>
+	);
+}
+
+interface PageActionsSheetProps {
+	visible: boolean;
+	onClose: () => void;
+	isCurrentPageFavorite: boolean;
+	isCurrentPageReading: boolean;
+	isCurrentPageWish: boolean;
+	isCurrentPageStar: boolean;
+	onFavoriteToggle: () => void;
+	onReadingToggle: () => void;
+	onWishToggle: () => void;
+	onStarToggle: () => void;
+	onShare: () => void;
+	onOpenAI: () => void;
+}
+
+/** 브라우저 헤더의 여러 상태 토글 버튼(즐겨찾기/읽는 중/위시/중요/공유/AI)을 하나의 버튼으로 모은 액션 시트 */
+export function PageActionsSheet({
+	visible,
+	onClose,
+	isCurrentPageFavorite,
+	isCurrentPageReading,
+	isCurrentPageWish,
+	isCurrentPageStar,
+	onFavoriteToggle,
+	onReadingToggle,
+	onWishToggle,
+	onStarToggle,
+	onShare,
+	onOpenAI,
+}: PageActionsSheetProps) {
+	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
+	const translateY = useSharedValue(SHEET_ANIMATION_DISTANCE);
+	const opacity = useSharedValue(0);
+	const [modalVisible, setModalVisible] = useState(false);
+
+	useEffect(() => {
+		if (visible) {
+			setModalVisible(true);
+			translateY.value = withTiming(0, { duration: 250 });
+			opacity.value = withTiming(1, { duration: 250 });
+		} else {
+			translateY.value = withTiming(SHEET_ANIMATION_DISTANCE, {
+				duration: 200,
+			});
+			opacity.value = withTiming(0, { duration: 200 });
+			const timer = setTimeout(() => setModalVisible(false), 210);
+			return () => clearTimeout(timer);
+		}
+	}, [visible, translateY, opacity]);
+
+	const sheetStyle = useAnimatedStyle(() => ({
+		transform: [{ translateY: translateY.value }],
+	}));
+
+	const overlayStyle = useAnimatedStyle(() => ({
+		opacity: opacity.value,
+	}));
+
+	const withClose = (action: () => void) => () => {
+		action();
+		onClose();
+	};
+
+	return (
+		<Modal visible={modalVisible} transparent statusBarTranslucent>
+			<View className="flex-1 justify-end">
+				<Animated.View
+					className="absolute inset-0 bg-black/40"
+					style={overlayStyle}
+				>
+					<Pressable className="absolute inset-0" onPress={onClose} />
+				</Animated.View>
+
+				<Animated.View
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
+					style={[sheetStyle, { paddingBottom: insets.bottom + 8 }]}
+				>
+					<View className="items-center py-2.5">
+						<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
+					</View>
+
+					<View className="flex-row justify-between items-center px-5 pb-2">
+						<Text className="text-lg font-bold text-foreground dark:text-white">
+							페이지 액션
+						</Text>
+						<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
+							<X size={22} color={isDark ? "#aaa" : "#666"} />
+						</TouchableOpacity>
+					</View>
+
+					<ActionRow
+						icon={
+							<Bookmark
+								size={20}
+								color={
+									isCurrentPageFavorite ? "#f59e0b" : isDark ? "#aaa" : "#666"
+								}
+								fill={isCurrentPageFavorite ? "#f59e0b" : "none"}
+							/>
+						}
+						label={isCurrentPageFavorite ? "즐겨찾기 해제" : "즐겨찾기"}
+						onPress={withClose(onFavoriteToggle)}
+					/>
+					<ActionRow
+						icon={
+							<BookOpen
+								size={20}
+								color={
+									isCurrentPageReading ? "#10b981" : isDark ? "#aaa" : "#666"
+								}
+							/>
+						}
+						label={isCurrentPageReading ? "읽는 중 해제" : "읽는 중으로 표시"}
+						onPress={withClose(onReadingToggle)}
+					/>
+					<ActionRow
+						icon={
+							<Heart
+								size={20}
+								color={isCurrentPageWish ? "#ec4899" : isDark ? "#aaa" : "#666"}
+								fill={isCurrentPageWish ? "#ec4899" : "none"}
+							/>
+						}
+						label={isCurrentPageWish ? "위시리스트 해제" : "위시리스트에 추가"}
+						onPress={withClose(onWishToggle)}
+					/>
+					<ActionRow
+						icon={
+							<Star
+								size={20}
+								color={isCurrentPageStar ? "#f59e0b" : isDark ? "#aaa" : "#666"}
+								fill={isCurrentPageStar ? "#f59e0b" : "none"}
+							/>
+						}
+						label={isCurrentPageStar ? "중요 해제" : "중요 표시"}
+						onPress={withClose(onStarToggle)}
+					/>
+					<ActionRow
+						icon={<Share2 size={20} color={isDark ? "#aaa" : "#666"} />}
+						label="공유"
+						onPress={withClose(onShare)}
+					/>
+					<ActionRow
+						icon={<Sparkles size={20} color="#7c3aed" />}
+						label="AI 요약/질문하기"
+						onPress={withClose(onOpenAI)}
+					/>
+				</Animated.View>
+			</View>
+		</Modal>
+	);
+}

--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -16,18 +16,21 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type WebView from "react-native-webview";
 import type { WebViewNavigation } from "react-native-webview";
 import { useAuth } from "@/lib/auth/AuthProvider";
+import { CONFIG } from "@/lib/config";
 import { useBrowserScroll } from "@/lib/context/BrowserScrollContext";
 import { useFavoriteToggle, useIsFavorite } from "@/lib/hooks/useFavorites";
 import {
 	useLocalMemoByUrl,
 	useLocalMemoDelete,
 	useLocalMemoReadingToggle,
+	useLocalMemoStarToggle,
 	useLocalMemoWishToggle,
 } from "@/lib/hooks/useLocalMemos";
 import { useSupabaseMemoByUrl } from "@/lib/hooks/useMemoByUrl";
 import {
 	useDeleteMemoMutation,
 	useMemoReadingToggleMutation,
+	useMemoStarToggleMutation,
 	useMemoWishToggleMutation,
 } from "@/lib/hooks/useMemoMutation";
 import { SCROLL_POSITIONS_QUERY_KEY } from "@/lib/hooks/useScrollPositions";
@@ -36,9 +39,11 @@ import {
 	getScrollPosition,
 	saveScrollPosition,
 } from "@/lib/storage/scrollPositions";
+import { supabase } from "@/lib/supabase/client";
 import { getPanelRatio, savePanelRatio } from "../_utils/browserPreferences";
 import { formatUrl } from "../_utils/formatUrl";
 import {
+	EXTRACT_PAGE_TEXT_JS,
 	INJECTED_JS_ON_NAVIGATION,
 	SCROLL_DETECT_JS,
 } from "../_utils/webViewScripts";
@@ -70,6 +75,15 @@ export function useBrowserState() {
 	const [contentHeight, setContentHeight] = useState(0);
 	const [wishToast, setWishToast] = useState<string | null>(null);
 	const [savedRatio, setSavedRatio] = useState(DEFAULT_PANEL_RATIO);
+	const [selectedText, setSelectedText] = useState<string | null>(null);
+	const [isActionsSheetOpen, setIsActionsSheetOpen] = useState(false);
+	const [isAISheetOpen, setIsAISheetOpen] = useState(false);
+	const [aiPageText, setAiPageText] = useState("");
+	const [aiSummary, setAiSummary] = useState<string | null>(null);
+	const [aiAnswer, setAiAnswer] = useState<string | null>(null);
+	const [aiQuestion, setAiQuestion] = useState("");
+	const [isAILoading, setIsAILoading] = useState(false);
+	const [aiError, setAiError] = useState<string | null>(null);
 
 	const { isLoggedIn } = useAuth();
 	const queryClient = useQueryClient();
@@ -91,6 +105,8 @@ export function useBrowserState() {
 	const wishToggleLocal = useLocalMemoWishToggle();
 	const readingToggleSupabase = useMemoReadingToggleMutation();
 	const readingToggleLocal = useLocalMemoReadingToggle();
+	const starToggleSupabase = useMemoStarToggleMutation();
+	const starToggleLocal = useLocalMemoStarToggle();
 	const deleteSupabaseMemo = useDeleteMemoMutation();
 	const deleteLocalMemo = useLocalMemoDelete();
 
@@ -101,6 +117,10 @@ export function useBrowserState() {
 	const isCurrentPageReading = isLoggedIn
 		? (supabaseMemo?.isReading ?? false)
 		: (localMemo?.isReading ?? false);
+
+	const isCurrentPageStar = isLoggedIn
+		? (supabaseMemo?.isStar ?? false)
+		: (localMemo?.isStar ?? false);
 
 	const { data: isCurrentPageFavorite } = useIsFavorite(currentUrl);
 	const favoriteToggle = useFavoriteToggle();
@@ -269,6 +289,32 @@ export function useBrowserState() {
 		readingToggleLocal,
 	]);
 
+	const handleStarToggle = useCallback(() => {
+		Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+		if (isLoggedIn) {
+			starToggleSupabase.mutate({
+				url: currentUrl,
+				title: pageTitle,
+				favIconUrl: pageFavIconUrl,
+				currentIsStar: isCurrentPageStar,
+			});
+		} else {
+			starToggleLocal.mutate({
+				url: currentUrl,
+				title: pageTitle,
+				favIconUrl: pageFavIconUrl,
+			});
+		}
+	}, [
+		currentUrl,
+		pageTitle,
+		pageFavIconUrl,
+		isLoggedIn,
+		isCurrentPageStar,
+		starToggleSupabase,
+		starToggleLocal,
+	]);
+
 	const handleWishToggle = useCallback(() => {
 		Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 
@@ -373,6 +419,47 @@ export function useBrowserState() {
 		[isMemoOpen, headerTranslateY, tabBarTranslateY, insets.bottom],
 	);
 
+	/** 기사 본문을 요약(question 없음) 또는 질의응답(question 있음) API에 요청한다 */
+	const requestArticleAI = useCallback(
+		async (pageText: string, question?: string) => {
+			setIsAILoading(true);
+			setAiError(null);
+			try {
+				const {
+					data: { session },
+				} = await supabase.auth.getSession();
+				const response = await fetch(
+					`${CONFIG.webappUrl}/api/openai/webpage-qa`,
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							...(session?.access_token
+								? { Authorization: `Bearer ${session.access_token}` }
+								: {}),
+						},
+						body: JSON.stringify({ content: pageText, question }),
+					},
+				);
+				const data = await response.json();
+				if (!response.ok) {
+					setAiError(data.error ?? "요청에 실패했어요");
+					return;
+				}
+				if (question) {
+					setAiAnswer(data.answer ?? null);
+				} else {
+					setAiSummary(data.summary ?? null);
+				}
+			} catch {
+				setAiError("요청에 실패했어요");
+			} finally {
+				setIsAILoading(false);
+			}
+		},
+		[],
+	);
+
 	const handleWebViewMessage = useCallback(
 		(event: { nativeEvent: { data: string } }) => {
 			try {
@@ -382,11 +469,53 @@ export function useBrowserState() {
 				} else if (message.type === "scroll") {
 					persistScrollPosition(message.scrollY, message.maxY ?? 0);
 					handleScrollMessage(message.direction, message.scrollY);
+				} else if (message.type === "textSelected" && message.text) {
+					setSelectedText(message.text);
+					if (!isMemoOpen) openPanel();
+				} else if (message.type === "pageTextExtracted") {
+					const text = message.text ?? "";
+					setAiPageText(text);
+					if (text.trim()) {
+						requestArticleAI(text);
+					} else {
+						setAiError("페이지에서 본문을 찾지 못했어요");
+						setIsAILoading(false);
+					}
 				}
 			} catch {}
 		},
-		[handleScrollMessage, persistScrollPosition],
+		[
+			handleScrollMessage,
+			persistScrollPosition,
+			isMemoOpen,
+			openPanel,
+			requestArticleAI,
+		],
 	);
+
+	const consumeSelectedText = useCallback(() => {
+		setSelectedText(null);
+	}, []);
+
+	const openAISheet = useCallback(() => {
+		setIsAISheetOpen(true);
+		setAiSummary(null);
+		setAiAnswer(null);
+		setAiQuestion("");
+		setAiError(null);
+		setIsAILoading(true);
+		webViewRef.current?.injectJavaScript(EXTRACT_PAGE_TEXT_JS);
+	}, []);
+
+	const closeAISheet = useCallback(() => {
+		setIsAISheetOpen(false);
+	}, []);
+
+	const askAIQuestion = useCallback(() => {
+		if (!aiQuestion.trim() || !aiPageText) return;
+		setAiAnswer(null);
+		requestArticleAI(aiPageText, aiQuestion.trim());
+	}, [aiQuestion, aiPageText, requestArticleAI]);
 
 	const toggleMemo = useCallback(() => {
 		if (isMemoOpen) {
@@ -451,9 +580,11 @@ export function useBrowserState() {
 		pageFavIconUrl,
 		isCurrentPageWish,
 		isCurrentPageReading,
+		isCurrentPageStar,
 		isCurrentPageFavorite: !!isCurrentPageFavorite,
 		handleFavoriteToggle,
 		handleReadingToggle,
+		handleStarToggle,
 		panelHeight,
 		headerWrapperStyle,
 		memoAnimatedStyle,
@@ -468,5 +599,19 @@ export function useBrowserState() {
 		handleBlogSelect,
 		handleShare,
 		SCROLL_DETECT_JS,
+		selectedText,
+		consumeSelectedText,
+		isActionsSheetOpen,
+		setIsActionsSheetOpen,
+		isAISheetOpen,
+		openAISheet,
+		closeAISheet,
+		aiSummary,
+		aiAnswer,
+		aiQuestion,
+		setAiQuestion,
+		isAILoading,
+		aiError,
+		askAIQuestion,
 	};
 }

--- a/apps/app/app/(main)/browser/_utils/webViewScripts.ts
+++ b/apps/app/app/(main)/browser/_utils/webViewScripts.ts
@@ -57,5 +57,35 @@ export const SCROLL_DETECT_JS = `
 })(); true;
 `;
 
+/** 텍스트 드래그 선택 감지 후 postMessage로 전달 (선택 종료 시 메모에 자동 기입용) */
+export const TEXT_SELECT_JS = `
+(function() {
+  if (window.__webmemoSelectSetup) return;
+  window.__webmemoSelectSetup = true;
+  var debounceTimer = null;
+  document.addEventListener('selectionchange', function() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function() {
+      var text = (window.getSelection() || '').toString().trim();
+      if (text.length > 1) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'textSelected', text: text }));
+      }
+    }, 400);
+  });
+})(); true;
+`;
+
+/** 현재 페이지 본문 텍스트를 추출해 postMessage로 전달 (AI 요약/질의응답용) */
+export const EXTRACT_PAGE_TEXT_JS = `
+(function() {
+  var text = (document.body && document.body.innerText) ? document.body.innerText : '';
+  window.ReactNativeWebView.postMessage(JSON.stringify({
+    type: 'pageTextExtracted',
+    title: document.title,
+    text: text.slice(0, 12000)
+  }));
+})(); true;
+`;
+
 /** 네비게이션 완료 시 injectJavaScript로 주입할 전체 스크립트 */
-export const INJECTED_JS_ON_NAVIGATION = `${FAVICON_EXTRACT_JS}\n${SCROLL_DETECT_JS}`;
+export const INJECTED_JS_ON_NAVIGATION = `${FAVICON_EXTRACT_JS}\n${SCROLL_DETECT_JS}\n${TEXT_SELECT_JS}`;

--- a/apps/app/app/(main)/browser/index.tsx
+++ b/apps/app/app/(main)/browser/index.tsx
@@ -3,10 +3,12 @@ import { KeyboardAvoidingView, Platform, Text, View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
 import { WebView } from "react-native-webview";
+import { AISheet } from "./_components/AISheet";
 import { BrowserHeader } from "./_components/BrowserHeader";
 import { DraggableFab } from "./_components/DraggableFab";
 import { EmptyBrowserView } from "./_components/EmptyBrowserView";
 import { MemoPanel } from "./_components/MemoPanel";
+import { PageActionsSheet } from "./_components/PageActionsSheet";
 import { TechBlogBottomSheet } from "./_components/TechBlogBottomSheet";
 import { useBrowserState } from "./_hooks/useBrowserState";
 
@@ -26,9 +28,11 @@ export default function BrowserScreen() {
 		pageFavIconUrl,
 		isCurrentPageWish,
 		isCurrentPageReading,
+		isCurrentPageStar,
 		isCurrentPageFavorite,
 		handleFavoriteToggle,
 		handleReadingToggle,
+		handleStarToggle,
 		panelHeight,
 		headerWrapperStyle,
 		memoAnimatedStyle,
@@ -42,6 +46,20 @@ export default function BrowserScreen() {
 		handleBlogSelect,
 		handleShare,
 		SCROLL_DETECT_JS,
+		selectedText,
+		consumeSelectedText,
+		isActionsSheetOpen,
+		setIsActionsSheetOpen,
+		isAISheetOpen,
+		openAISheet,
+		closeAISheet,
+		aiSummary,
+		aiAnswer,
+		aiQuestion,
+		setAiQuestion,
+		isAILoading,
+		aiError,
+		askAIQuestion,
 	} = useBrowserState();
 
 	if (!currentUrl) {
@@ -56,18 +74,22 @@ export default function BrowserScreen() {
 		);
 	}
 
+	const hasActiveStatus =
+		isCurrentPageFavorite ||
+		isCurrentPageReading ||
+		isCurrentPageWish ||
+		isCurrentPageStar;
+
 	return (
 		<KeyboardAvoidingView
-			className="flex-1 bg-white"
+			className="flex-1 bg-white dark:bg-neutral-900"
 			style={{ paddingTop: insets.top }}
 			behavior={Platform.OS === "ios" ? "padding" : undefined}
 		>
 			<BrowserHeader
 				urlInput={urlInput}
 				currentUrl={currentUrl}
-				isCurrentPageWish={isCurrentPageWish}
-				isCurrentPageReading={isCurrentPageReading}
-				isCurrentPageFavorite={isCurrentPageFavorite}
+				hasActiveStatus={hasActiveStatus}
 				headerWrapperStyle={headerWrapperStyle}
 				webViewRef={webViewRef}
 				onUrlInputChange={setUrlInput}
@@ -77,10 +99,7 @@ export default function BrowserScreen() {
 					handleBlogSelect("");
 				}}
 				onOpenBlogSheet={() => setIsBlogSheetOpen(true)}
-				onFavoriteToggle={handleFavoriteToggle}
-				onReadingToggle={handleReadingToggle}
-				onWishToggle={handleWishToggle}
-				onShare={handleShare}
+				onOpenActions={() => setIsActionsSheetOpen(true)}
 			/>
 
 			<View
@@ -103,12 +122,12 @@ export default function BrowserScreen() {
 				</View>
 
 				<Animated.View
-					className="border-t border-border bg-white overflow-hidden"
+					className="border-t border-border dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden"
 					style={memoAnimatedStyle}
 				>
 					<GestureDetector gesture={resizeGesture}>
 						<Animated.View className="items-center justify-center py-2">
-							<View className="w-9 h-1 rounded-sm bg-gray-300" />
+							<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
 						</Animated.View>
 					</GestureDetector>
 					<MemoPanel
@@ -116,6 +135,8 @@ export default function BrowserScreen() {
 						pageTitle={pageTitle}
 						favIconUrl={pageFavIconUrl}
 						onClose={closePanel}
+						selectedText={selectedText}
+						onSelectedTextConsumed={consumeSelectedText}
 					/>
 				</Animated.View>
 			</View>
@@ -145,6 +166,33 @@ export default function BrowserScreen() {
 					setIsBlogSheetOpen(false);
 					handleBlogSelect(url);
 				}}
+			/>
+
+			<PageActionsSheet
+				visible={isActionsSheetOpen}
+				onClose={() => setIsActionsSheetOpen(false)}
+				isCurrentPageFavorite={isCurrentPageFavorite}
+				isCurrentPageReading={isCurrentPageReading}
+				isCurrentPageWish={isCurrentPageWish}
+				isCurrentPageStar={isCurrentPageStar}
+				onFavoriteToggle={handleFavoriteToggle}
+				onReadingToggle={handleReadingToggle}
+				onWishToggle={handleWishToggle}
+				onStarToggle={handleStarToggle}
+				onShare={handleShare}
+				onOpenAI={openAISheet}
+			/>
+
+			<AISheet
+				visible={isAISheetOpen}
+				onClose={closeAISheet}
+				summary={aiSummary}
+				answer={aiAnswer}
+				question={aiQuestion}
+				onQuestionChange={setAiQuestion}
+				onAskQuestion={askAIQuestion}
+				isLoading={isAILoading}
+				error={aiError}
 			/>
 		</KeyboardAvoidingView>
 	);

--- a/apps/web/src/app/api/openai/webpage-qa/constant.ts
+++ b/apps/web/src/app/api/openai/webpage-qa/constant.ts
@@ -1,0 +1,13 @@
+export const OPENAI_MODEL = "gpt-4o-mini" as const;
+
+export const OPENAI_SETTINGS = {
+	temperature: 0.3,
+} as const;
+
+export const PAGE_CONTENT_MAX_LENGTH = 12000;
+
+export const SUMMARIZE_SYSTEM_MESSAGE =
+	"You are a helpful assistant that summarizes web articles in Korean. Write a concise summary in 3-5 bullet points, in Korean, no markdown headers.";
+
+export const QA_SYSTEM_MESSAGE =
+	"You are a helpful assistant that answers questions about a web article's content, in Korean. If the article does not contain the answer, say so honestly.";

--- a/apps/web/src/app/api/openai/webpage-qa/route.ts
+++ b/apps/web/src/app/api/openai/webpage-qa/route.ts
@@ -1,0 +1,116 @@
+import { createClient } from "@supabase/supabase-js";
+import { CONFIG } from "@web-memo/env";
+import { type NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+import { CORS_HEADERS, ERROR_MESSAGES, HTTP_STATUS } from "../constant";
+import { createErrorResponse, handleOpenAIError } from "../util";
+import {
+	OPENAI_MODEL,
+	OPENAI_SETTINGS,
+	PAGE_CONTENT_MAX_LENGTH,
+	QA_SYSTEM_MESSAGE,
+	SUMMARIZE_SYSTEM_MESSAGE,
+} from "./constant";
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!OPENAI_API_KEY) {
+	console.warn("OPENAI_API_KEY is not configured");
+}
+
+/** 요청의 Bearer 토큰이 로그인한 사용자의 것인지 검증한다 (앱은 origin 헤더를 보내지 않음) */
+const verifyUser = async (request: NextRequest) => {
+	const authHeader = request.headers.get("authorization");
+	const token = authHeader?.replace("Bearer ", "");
+	if (!token) return null;
+
+	const supabase = createClient(CONFIG.supabaseUrl, CONFIG.supabaseAnonKey);
+	const {
+		data: { user },
+	} = await supabase.auth.getUser(token);
+	return user;
+};
+
+export async function POST(request: NextRequest) {
+	if (!OPENAI_API_KEY) {
+		return createErrorResponse(
+			"OpenAI API key not configured",
+			HTTP_STATUS.INTERNAL_SERVER_ERROR,
+		);
+	}
+
+	try {
+		const user = await verifyUser(request);
+		if (!user) {
+			return createErrorResponse(
+				ERROR_MESSAGES.UNAUTHORIZED,
+				HTTP_STATUS.FORBIDDEN,
+			);
+		}
+
+		const body = await request.json();
+		const content = typeof body.content === "string" ? body.content : "";
+		const question = typeof body.question === "string" ? body.question : "";
+
+		if (!content.trim()) {
+			return createErrorResponse(
+				"content가 필요합니다.",
+				HTTP_STATUS.BAD_REQUEST,
+			);
+		}
+
+		const truncatedContent = content.slice(0, PAGE_CONTENT_MAX_LENGTH);
+		const isQuestion = !!question.trim();
+
+		const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+		const completion = await openai.chat.completions.create({
+			model: OPENAI_MODEL,
+			messages: [
+				{
+					role: "system",
+					content: isQuestion ? QA_SYSTEM_MESSAGE : SUMMARIZE_SYSTEM_MESSAGE,
+				},
+				{
+					role: "user",
+					content: isQuestion
+						? `기사 본문:\n${truncatedContent}\n\n질문: ${question.trim()}`
+						: `다음 기사를 요약해줘:\n${truncatedContent}`,
+				},
+			],
+			temperature: OPENAI_SETTINGS.temperature,
+		});
+
+		const responseContent = completion.choices[0]?.message?.content;
+
+		if (!responseContent) {
+			return NextResponse.json(
+				{ [isQuestion ? "answer" : "summary"]: null },
+				{ headers: CORS_HEADERS },
+			);
+		}
+
+		return NextResponse.json(
+			{ [isQuestion ? "answer" : "summary"]: responseContent },
+			{ headers: CORS_HEADERS },
+		);
+	} catch (error) {
+		console.error("Webpage QA error:", error);
+
+		if (error instanceof Error) {
+			return handleOpenAIError(error);
+		}
+
+		return createErrorResponse(
+			ERROR_MESSAGES.GENERAL_SERVER_ERROR,
+			HTTP_STATUS.INTERNAL_SERVER_ERROR,
+		);
+	}
+}
+
+export async function OPTIONS() {
+	return new Response(null, {
+		status: 200,
+		headers: CORS_HEADERS,
+	});
+}


### PR DESCRIPTION
## 개요
브라우저 화면의 상태 토글 버튼 통합, 텍스트 드래그 시 메모 자동 기입, AI 요약/질의응답 기능 추가.

## 작업 사항
- 즐겨찾기/읽는 중/위시/공유 아이콘과 신규 "중요" 토글을 헤더의 단일 "더보기" 버튼 + 액션 시트(PageActionsSheet)로 통합
- 브라우저 화면에 없던 "중요(isStar)" 토글을 새로 연결(기존 memo 리스트/상세에는 이미 있던 필드)
- WebView에서 텍스트를 드래그로 선택하면 자동으로 메모 본문에 덧붙여지는 기능 추가
- 현재 보고 있는 페이지 본문을 AI로 요약하고, 이어서 질문할 수 있는 시트(AISheet) 추가 — 앱 전용, 로그인 사용자만 사용 가능
- 웹에 `/api/openai/webpage-qa` 라우트 신규 추가: 기존 openai 연동(gpt-4o-mini)을 재사용하되, chrome-extension origin 체크 대신 Supabase 액세스 토큰으로 인증

## 테스트
- `@web-memo/app`, `@web-memo/web` type-check 통과
- 변경/신규 파일 biome check 통과(기존 TechBlogBottomSheet.tsx의 사전 존재 경고 4건은 이번 변경과 무관)
