### PR TITLE
앱 전체 다크모드 + 수동 테마 선택 기능

### DIFF
--- a/apps/app/app/(auth)/login/index.tsx
+++ b/apps/app/app/(auth)/login/index.tsx
@@ -36,7 +36,7 @@ export default function LoginScreen() {
 	};
 
 	return (
-		<SafeAreaView className="flex-1 bg-white">
+		<SafeAreaView className="flex-1 bg-white dark:bg-neutral-950">
 			<View className="flex-1 justify-center px-8">
 				<View className="items-center mb-10 gap-3">
 					<Image
@@ -45,7 +45,7 @@ export default function LoginScreen() {
 						resizeMode="contain"
 					/>
 					<Text className="text-2xl font-bold text-foreground">웹 메모</Text>
-					<Text className="text-sm text-gray-500 text-center">
+					<Text className="text-sm text-gray-500 dark:text-neutral-400 text-center">
 						아티클 읽으며 간편하게 메모하세요.
 					</Text>
 				</View>

--- a/apps/app/app/(main)/_components/AddMemoModal.tsx
+++ b/apps/app/app/(main)/_components/AddMemoModal.tsx
@@ -1,4 +1,5 @@
 import { Link2, Save, Type, X } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useState } from "react";
 import {
 	ActivityIndicator,
@@ -9,7 +10,6 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -37,7 +37,7 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 	const insets = useSafeAreaInsets();
 	const { isLoggedIn } = useAuth();
 	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	const [titleText, setTitleText] = useState("");
 	const [urlText, setUrlText] = useState("");

--- a/apps/app/app/(main)/_components/AddMemoModal.tsx
+++ b/apps/app/app/(main)/_components/AddMemoModal.tsx
@@ -146,15 +146,26 @@ export function AddMemoModal({ visible, onClose }: AddMemoModalProps) {
 								activeOpacity={0.8}
 							>
 								{isSaving ? (
-									<ActivityIndicator size="small" color="#fff" />
+									<ActivityIndicator
+										size="small"
+										color={isDark ? "#111" : "#fff"}
+									/>
 								) : (
 									<Save
 										size={16}
-										color={hasContent ? "#fff" : isDark ? "#666" : "#999"}
+										color={
+											hasContent
+												? isDark
+													? "#111"
+													: "#fff"
+												: isDark
+													? "#666"
+													: "#999"
+										}
 									/>
 								)}
 								<Text
-									className={`text-sm font-semibold ${hasContent ? "text-white" : "text-gray-400 dark:text-neutral-500"}`}
+									className={`text-sm font-semibold ${hasContent ? "text-background" : "text-gray-400 dark:text-neutral-500"}`}
 								>
 									저장
 								</Text>

--- a/apps/app/app/(main)/_components/CustomTabBar.tsx
+++ b/apps/app/app/(main)/_components/CustomTabBar.tsx
@@ -5,7 +5,7 @@ import {
 	type LucideIcon,
 	Settings,
 } from "lucide-react-native";
-import { Text, TouchableOpacity, View } from "react-native";
+import { Text, TouchableOpacity, useColorScheme, View } from "react-native";
 import Animated, {
 	useAnimatedStyle,
 	useSharedValue,
@@ -32,6 +32,7 @@ export function CustomTabBar({
 	navigation,
 }: CustomTabBarProps) {
 	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
 	const { tabBarTranslateY, isBrowserActive } = useBrowserScroll();
 	const barHeight = useSharedValue(0);
 
@@ -47,7 +48,7 @@ export function CustomTabBar({
 	return (
 		<Animated.View style={wrapperStyle}>
 			<View
-				className="flex-row bg-white border-t border-border pt-2"
+				className="flex-row bg-white dark:bg-neutral-900 border-t border-border pt-2"
 				style={{ paddingBottom: insets.bottom }}
 				onLayout={(e) => {
 					if (barHeight.value === 0) {
@@ -80,7 +81,10 @@ export function CustomTabBar({
 							className="flex-1 items-center justify-center py-1 gap-0.5"
 							activeOpacity={0.7}
 						>
-							<Icon size={22} color={isFocused ? "#111" : "#999"} />
+							<Icon
+								size={22}
+								color={isFocused ? (isDark ? "#eee" : "#111") : "#999"}
+							/>
 							<Text
 								className={`text-[11px] mt-0.5 ${isFocused ? "text-foreground font-semibold" : "text-muted-foreground"}`}
 							>

--- a/apps/app/app/(main)/_components/CustomTabBar.tsx
+++ b/apps/app/app/(main)/_components/CustomTabBar.tsx
@@ -5,7 +5,8 @@ import {
 	type LucideIcon,
 	Settings,
 } from "lucide-react-native";
-import { Text, TouchableOpacity, useColorScheme, View } from "react-native";
+import { useColorScheme } from "nativewind";
+import { Text, TouchableOpacity, View } from "react-native";
 import Animated, {
 	useAnimatedStyle,
 	useSharedValue,
@@ -32,7 +33,7 @@ export function CustomTabBar({
 	navigation,
 }: CustomTabBarProps) {
 	const insets = useSafeAreaInsets();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const { tabBarTranslateY, isBrowserActive } = useBrowserScroll();
 	const barHeight = useSharedValue(0);
 

--- a/apps/app/app/(main)/_components/MemoCard.tsx
+++ b/apps/app/app/(main)/_components/MemoCard.tsx
@@ -1,13 +1,8 @@
 import type { GetMemoResponse } from "@web-memo/shared/types";
 import { BookOpen, FileText, Heart, Star, Trash2 } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useRef } from "react";
-import {
-	Image,
-	Text,
-	TouchableOpacity,
-	useColorScheme,
-	View,
-} from "react-native";
+import { Image, Text, TouchableOpacity, View } from "react-native";
 import ReanimatedSwipeable, {
 	type SwipeableMethods,
 } from "react-native-gesture-handler/ReanimatedSwipeable";
@@ -49,7 +44,7 @@ export function MemoCard({
 	onDelete,
 }: MemoCardProps) {
 	const swipeableRef = useRef<SwipeableMethods>(null);
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	const rawDate =
 		"updated_at" in memo

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -10,6 +10,7 @@ import {
 	StarOff,
 	X,
 } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useCallback, useEffect, useState } from "react";
 import {
 	Dimensions,
@@ -23,7 +24,6 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -75,7 +75,7 @@ export function MemoDetailModal({
 	} = useSettingQuery(isLoggedIn);
 	const showImpression = showImpressionSetting || !!memo?.impression;
 	const showActionItem = showActionItemSetting || !!memo?.actionItem;
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);

--- a/apps/app/app/(main)/_components/MemoDetailModal.tsx
+++ b/apps/app/app/(main)/_components/MemoDetailModal.tsx
@@ -286,10 +286,18 @@ export function MemoDetailModal({
 								>
 									<Save
 										size={14}
-										color={isMemoEdited ? "#fff" : isDark ? "#666" : "#999"}
+										color={
+											isMemoEdited
+												? isDark
+													? "#111"
+													: "#fff"
+												: isDark
+													? "#666"
+													: "#999"
+										}
 									/>
 									<Text
-										className={`text-sm font-semibold ${isMemoEdited ? "text-white" : "text-gray-400 dark:text-neutral-500"}`}
+										className={`text-sm font-semibold ${isMemoEdited ? "text-background" : "text-gray-400 dark:text-neutral-500"}`}
 									>
 										저장
 									</Text>

--- a/apps/app/app/(main)/browser/_components/AISheet.tsx
+++ b/apps/app/app/(main)/browser/_components/AISheet.tsx
@@ -1,4 +1,5 @@
 import { Send, Sparkles, X } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useEffect, useState } from "react";
 import {
 	ActivityIndicator,
@@ -10,7 +11,6 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -47,7 +47,7 @@ export function AISheet({
 	error,
 }: AISheetProps) {
 	const insets = useSafeAreaInsets();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const translateY = useSharedValue(SHEET_ANIMATION_DISTANCE);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);

--- a/apps/app/app/(main)/browser/_components/AISheet.tsx
+++ b/apps/app/app/(main)/browser/_components/AISheet.tsx
@@ -185,7 +185,7 @@ export function AISheet({
 							onPress={onAskQuestion}
 							disabled={isLoading || !question.trim()}
 						>
-							<Send size={16} color="#fff" />
+							<Send size={16} color={isDark ? "#111" : "#fff"} />
 						</TouchableOpacity>
 					</View>
 				</Animated.View>

--- a/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
+++ b/apps/app/app/(main)/browser/_components/BrowserHeader.tsx
@@ -6,12 +6,8 @@ import {
 	Search,
 	X,
 } from "lucide-react-native";
-import {
-	TextInput,
-	TouchableOpacity,
-	useColorScheme,
-	View,
-} from "react-native";
+import { useColorScheme } from "nativewind";
+import { TextInput, TouchableOpacity, View } from "react-native";
 import Animated from "react-native-reanimated";
 import type WebView from "react-native-webview";
 
@@ -42,7 +38,7 @@ export function BrowserHeader({
 	onOpenBlogSheet,
 	onOpenActions,
 }: BrowserHeaderProps) {
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	return (
 		<Animated.View className="overflow-hidden" style={headerWrapperStyle}>

--- a/apps/app/app/(main)/browser/_components/DraggableFab.tsx
+++ b/apps/app/app/(main)/browser/_components/DraggableFab.tsx
@@ -1,6 +1,7 @@
 import { PenLine } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useEffect } from "react";
-import { Dimensions, useColorScheme } from "react-native";
+import { Dimensions } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
 	runOnJS,
@@ -28,7 +29,7 @@ export function DraggableFab({
 	bottomInset,
 }: DraggableFabProps) {
 	const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	const fabOffsetX = useSharedValue(screenWidth - FAB_SIZE - EDGE_MARGIN);
 	const fabOffsetY = useSharedValue(screenHeight - FAB_SIZE - bottomInset - 80);

--- a/apps/app/app/(main)/browser/_components/DraggableFab.tsx
+++ b/apps/app/app/(main)/browser/_components/DraggableFab.tsx
@@ -1,6 +1,6 @@
 import { PenLine } from "lucide-react-native";
 import { useEffect } from "react";
-import { Dimensions } from "react-native";
+import { Dimensions, useColorScheme } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
 	runOnJS,
@@ -28,6 +28,7 @@ export function DraggableFab({
 	bottomInset,
 }: DraggableFabProps) {
 	const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
+	const isDark = useColorScheme() === "dark";
 
 	const fabOffsetX = useSharedValue(screenWidth - FAB_SIZE - EDGE_MARGIN);
 	const fabOffsetY = useSharedValue(screenHeight - FAB_SIZE - bottomInset - 80);
@@ -115,7 +116,7 @@ export function DraggableFab({
 					fabAnimatedStyle,
 				]}
 			>
-				<PenLine size={24} color="#fff" />
+				<PenLine size={24} color={isDark ? "#111" : "#fff"} />
 			</Animated.View>
 		</GestureDetector>
 	);

--- a/apps/app/app/(main)/browser/_components/EmptyBrowserView.tsx
+++ b/apps/app/app/(main)/browser/_components/EmptyBrowserView.tsx
@@ -1,5 +1,6 @@
 import { Search } from "lucide-react-native";
-import { ScrollView, TextInput, useColorScheme, View } from "react-native";
+import { useColorScheme } from "nativewind";
+import { ScrollView, TextInput, View } from "react-native";
 import type { EdgeInsets } from "react-native-safe-area-context";
 import { FavoriteLinks } from "./FavoriteLinks";
 import { TechBlogLinks } from "./TechBlogLinks";
@@ -19,7 +20,7 @@ export function EmptyBrowserView({
 	onUrlSubmit,
 	onSelectBlog,
 }: EmptyBrowserViewProps) {
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	return (
 		<View

--- a/apps/app/app/(main)/browser/_components/EmptyBrowserView.tsx
+++ b/apps/app/app/(main)/browser/_components/EmptyBrowserView.tsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react-native";
-import { ScrollView, TextInput, View } from "react-native";
+import { ScrollView, TextInput, useColorScheme, View } from "react-native";
 import type { EdgeInsets } from "react-native-safe-area-context";
 import { FavoriteLinks } from "./FavoriteLinks";
 import { TechBlogLinks } from "./TechBlogLinks";
@@ -19,19 +19,24 @@ export function EmptyBrowserView({
 	onUrlSubmit,
 	onSelectBlog,
 }: EmptyBrowserViewProps) {
+	const isDark = useColorScheme() === "dark";
+
 	return (
-		<View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
+		<View
+			className="flex-1 bg-white dark:bg-neutral-950"
+			style={{ paddingTop: insets.top }}
+		>
 			<ScrollView className="flex-1 pt-4" keyboardShouldPersistTaps="handled">
 				<View className="px-5">
-					<View className="flex-row items-center bg-input rounded-[14px] px-3.5 py-3 gap-2.5">
-						<Search size={18} color="#999" />
+					<View className="flex-row items-center bg-input dark:bg-neutral-800 rounded-[14px] px-3.5 py-3 gap-2.5">
+						<Search size={18} color={isDark ? "#777" : "#999"} />
 						<TextInput
-							className="flex-1 text-base text-[#333] p-0"
+							className="flex-1 text-base text-[#333] dark:text-white p-0"
 							value={urlInput}
 							onChangeText={onUrlInputChange}
 							onSubmitEditing={onUrlSubmit}
 							placeholder="검색어를 입력하세요"
-							placeholderTextColor="#999"
+							placeholderTextColor={isDark ? "#666" : "#999"}
 							autoCapitalize="none"
 							autoCorrect={false}
 							keyboardType="default"

--- a/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
@@ -1,4 +1,5 @@
 import { Bookmark } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useState } from "react";
 import {
 	Alert,
@@ -6,7 +7,6 @@ import {
 	Image,
 	Text,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import { useFavoriteRemove, useFavorites } from "@/lib/hooks/useFavorites";
@@ -18,7 +18,7 @@ interface FavoriteLinksProps {
 export function FavoriteLinks({ onSelectUrl }: FavoriteLinksProps) {
 	const { data: favorites } = useFavorites();
 	const removeFavorite = useFavoriteRemove();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	if (!favorites || favorites.length === 0) {
 		return (

--- a/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
@@ -6,6 +6,7 @@ import {
 	Image,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useFavoriteRemove, useFavorites } from "@/lib/hooks/useFavorites";
@@ -17,6 +18,7 @@ interface FavoriteLinksProps {
 export function FavoriteLinks({ onSelectUrl }: FavoriteLinksProps) {
 	const { data: favorites } = useFavorites();
 	const removeFavorite = useFavoriteRemove();
+	const isDark = useColorScheme() === "dark";
 
 	if (!favorites || favorites.length === 0) {
 		return (
@@ -25,7 +27,7 @@ export function FavoriteLinks({ onSelectUrl }: FavoriteLinksProps) {
 					즐겨찾기
 				</Text>
 				<View className="items-center py-6 bg-card rounded-xl border border-border">
-					<Bookmark size={24} color="#ddd" />
+					<Bookmark size={24} color={isDark ? "#444" : "#ddd"} />
 					<Text className="text-[13px] text-muted-foreground mt-2">
 						자주 방문하는 페이지를 즐겨찾기에 추가해보세요
 					</Text>
@@ -104,10 +106,10 @@ function FavoriteItem({
 					/>
 				) : (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{(domain || "?").charAt(0).toUpperCase()}
 						</Text>
 					</View>

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -207,13 +207,18 @@ export function MemoPanel({
 						}
 					>
 						{isPending ? (
-							<ActivityIndicator size="small" color="#fff" />
+							<ActivityIndicator
+								size="small"
+								color={isDark ? "#111" : "#fff"}
+							/>
 						) : saved ? (
 							<Check size={16} color="#fff" />
 						) : (
-							<Save size={16} color="#fff" />
+							<Save size={16} color={isDark ? "#111" : "#fff"} />
 						)}
-						<Text className="text-white text-sm font-semibold">
+						<Text
+							className={`text-sm font-semibold ${saved ? "text-white" : "text-background"}`}
+						>
 							{saved ? "저장됨" : "저장"}
 						</Text>
 					</TouchableOpacity>

--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -1,4 +1,5 @@
 import { Check, ChevronDown, FileText, Save, X } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useEffect, useRef, useState } from "react";
 import {
 	ActivityIndicator,
@@ -9,7 +10,6 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import { useAuth } from "@/lib/auth/AuthProvider";
@@ -39,7 +39,7 @@ export function MemoPanel({
 	onSelectedTextConsumed,
 }: MemoPanelProps) {
 	const { isLoggedIn } = useAuth();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	const [titleText, setTitleText] = useState("");
 	const [memoText, setMemoText] = useState("");

--- a/apps/app/app/(main)/browser/_components/PageActionsSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/PageActionsSheet.tsx
@@ -7,15 +7,9 @@ import {
 	Star,
 	X,
 } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useEffect, useState } from "react";
-import {
-	Modal,
-	Pressable,
-	Text,
-	TouchableOpacity,
-	useColorScheme,
-	View,
-} from "react-native";
+import { Modal, Pressable, Text, TouchableOpacity, View } from "react-native";
 import Animated, {
 	useAnimatedStyle,
 	useSharedValue,
@@ -77,7 +71,7 @@ export function PageActionsSheet({
 	onOpenAI,
 }: PageActionsSheetProps) {
 	const insets = useSafeAreaInsets();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const translateY = useSharedValue(SHEET_ANIMATION_DISTANCE);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);

--- a/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
@@ -1,5 +1,6 @@
 import { URL as APP_URL } from "@web-memo/shared/constants";
 import { Bookmark, MessageCircle, X } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useEffect, useState } from "react";
 import {
 	Alert,
@@ -11,7 +12,6 @@ import {
 	ScrollView,
 	Text,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -233,7 +233,7 @@ export function TechBlogBottomSheet({
 	onSelectBlog: (url: string) => void;
 }) {
 	const insets = useSafeAreaInsets();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);

--- a/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
@@ -11,6 +11,7 @@ import {
 	ScrollView,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -54,10 +55,10 @@ function SheetBlogItem({
 			<View className="w-14 h-14 rounded-[14px] bg-input justify-center items-center overflow-hidden">
 				{!logoUri || imgError ? (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{blog.name.charAt(0)}
 						</Text>
 					</View>
@@ -144,10 +145,10 @@ function FavoriteGridItem({
 					/>
 				) : (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{(domain || "?").charAt(0).toUpperCase()}
 						</Text>
 					</View>
@@ -193,7 +194,9 @@ function FavoritesSection({ onPress }: { onPress: (url: string) => void }) {
 		<>
 			<View className="flex-row items-center gap-1.5 px-2 mb-3">
 				<Bookmark size={14} color="#f59e0b" fill="#f59e0b" />
-				<Text className="text-sm font-semibold text-gray-500">즐겨찾기</Text>
+				<Text className="text-sm font-semibold text-gray-500 dark:text-neutral-400">
+					즐겨찾기
+				</Text>
 			</View>
 			<View className="mb-6">
 				{rows.map((row, rowIndex) => (
@@ -230,6 +233,7 @@ export function TechBlogBottomSheet({
 	onSelectBlog: (url: string) => void;
 }) {
 	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
@@ -266,20 +270,20 @@ export function TechBlogBottomSheet({
 				</Animated.View>
 
 				<Animated.View
-					className="bg-white rounded-t-[20px]"
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
 					style={[
 						sheetStyle,
 						{ height: SHEET_HEIGHT, paddingBottom: insets.bottom + 16 },
 					]}
 				>
 					<View className="items-center py-2.5">
-						<View className="w-9 h-1 rounded-sm bg-gray-300" />
+						<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
 					</View>
 
 					<View className="flex-row justify-between items-center px-5 pb-4">
 						<Text className="text-lg font-bold text-foreground">바로가기</Text>
 						<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
-							<X size={22} color="#666" />
+							<X size={22} color={isDark ? "#aaa" : "#666"} />
 						</TouchableOpacity>
 					</View>
 
@@ -289,12 +293,12 @@ export function TechBlogBottomSheet({
 					>
 						<FavoritesSection onPress={onSelectBlog} />
 
-						<Text className="text-sm font-semibold text-gray-500 px-2 mb-3">
+						<Text className="text-sm font-semibold text-gray-500 dark:text-neutral-400 px-2 mb-3">
 							블로그 모음
 						</Text>
 						<BlogGrid blogs={BLOG_AGGREGATORS} onPress={onSelectBlog} />
 
-						<Text className="text-sm font-semibold text-gray-500 px-2 mb-3 mt-6">
+						<Text className="text-sm font-semibold text-gray-500 dark:text-neutral-400 px-2 mb-3 mt-6">
 							테크 블로그
 						</Text>
 						<BlogGrid blogs={TECH_BLOGS} onPress={onSelectBlog} />
@@ -304,8 +308,8 @@ export function TechBlogBottomSheet({
 							onPress={() => Linking.openURL(APP_URL.kakaoTalk)}
 							activeOpacity={0.7}
 						>
-							<MessageCircle size={16} color="#666" />
-							<Text className="text-sm text-gray-500 font-medium">
+							<MessageCircle size={16} color={isDark ? "#aaa" : "#666"} />
+							<Text className="text-sm text-gray-500 dark:text-neutral-400 font-medium">
 								블로그 추가 문의하기
 							</Text>
 						</TouchableOpacity>

--- a/apps/app/app/(main)/browser/_components/TechBlogLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogLinks.tsx
@@ -7,6 +7,7 @@ import {
 	Linking,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import {
@@ -41,10 +42,10 @@ function BlogItem({
 			<View className="w-14 h-14 rounded-[14px] bg-input justify-center items-center overflow-hidden">
 				{!logoUri || imgError ? (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{blog.name.charAt(0)}
 						</Text>
 					</View>
@@ -73,6 +74,7 @@ export function TechBlogLinks({
 	onSelectBlog: (url: string) => void;
 }) {
 	const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
+	const isDark = useColorScheme() === "dark";
 
 	const renderItem = useCallback(
 		({ item }: { item: TechBlog }) => (
@@ -91,7 +93,7 @@ export function TechBlogLinks({
 					activeOpacity={0.7}
 				>
 					<Text className="text-[13px] text-muted-foreground">전체보기</Text>
-					<ChevronRight size={14} color="#999" />
+					<ChevronRight size={14} color={isDark ? "#777" : "#999"} />
 				</TouchableOpacity>
 			</View>
 
@@ -122,8 +124,8 @@ export function TechBlogLinks({
 				onPress={() => Linking.openURL(URL.kakaoTalk)}
 				activeOpacity={0.7}
 			>
-				<MessageCircle size={16} color="#666" />
-				<Text className="text-sm text-gray-500 font-medium">
+				<MessageCircle size={16} color={isDark ? "#aaa" : "#666"} />
+				<Text className="text-sm text-gray-500 dark:text-neutral-400 font-medium">
 					블로그 추가 문의하기
 				</Text>
 			</TouchableOpacity>

--- a/apps/app/app/(main)/browser/_components/TechBlogLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogLinks.tsx
@@ -1,5 +1,6 @@
 import { URL } from "@web-memo/shared/constants";
 import { ChevronRight, MessageCircle } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useCallback, useState } from "react";
 import {
 	FlatList,
@@ -7,7 +8,6 @@ import {
 	Linking,
 	Text,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import {
@@ -74,7 +74,7 @@ export function TechBlogLinks({
 	onSelectBlog: (url: string) => void;
 }) {
 	const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 
 	const renderItem = useCallback(
 		({ item }: { item: TechBlog }) => (

--- a/apps/app/app/(main)/index.tsx
+++ b/apps/app/app/(main)/index.tsx
@@ -8,13 +8,13 @@ import {
 	Star,
 	Undo2,
 } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useCallback, useEffect, useState } from "react";
 import {
 	ActivityIndicator,
 	FlatList,
 	Text,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -30,7 +30,7 @@ const READ_DONE_PROGRESS = 0.98;
 
 export default function MemoScreen() {
 	const insets = useSafeAreaInsets();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const router = useRouter();
 	const { filter: filterParam } = useLocalSearchParams<{ filter?: string }>();
 	const [selectedMemo, setSelectedMemo] = useState<MemoItem | null>(null);

--- a/apps/app/app/(main)/index.tsx
+++ b/apps/app/app/(main)/index.tsx
@@ -14,6 +14,7 @@ import {
 	FlatList,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -29,6 +30,7 @@ const READ_DONE_PROGRESS = 0.98;
 
 export default function MemoScreen() {
 	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
 	const router = useRouter();
 	const { filter: filterParam } = useLocalSearchParams<{ filter?: string }>();
 	const [selectedMemo, setSelectedMemo] = useState<MemoItem | null>(null);
@@ -95,8 +97,10 @@ export default function MemoScreen() {
 								className="flex-row items-center gap-1.5 px-3 py-1.5 rounded-full bg-foreground"
 								onPress={() => router.navigate("/(auth)/login")}
 							>
-								<LogIn size={14} color="#fff" />
-								<Text className="text-xs font-semibold text-white">로그인</Text>
+								<LogIn size={14} color={isDark ? "#111" : "#fff"} />
+								<Text className="text-xs font-semibold text-background">
+									로그인
+								</Text>
 							</TouchableOpacity>
 						) : null}
 						<TouchableOpacity
@@ -104,15 +108,15 @@ export default function MemoScreen() {
 							onPress={() => setIsAddModalOpen(true)}
 							activeOpacity={0.8}
 						>
-							<Plus size={14} color="#fff" />
-							<Text className="text-xs font-semibold text-white">
+							<Plus size={14} color={isDark ? "#111" : "#fff"} />
+							<Text className="text-xs font-semibold text-background">
 								메모 추가
 							</Text>
 						</TouchableOpacity>
 					</View>
 				</View>
 
-				<Text className="text-sm text-gray-400 px-5 mb-4">
+				<Text className="text-sm text-gray-400 dark:text-neutral-500 px-5 mb-4">
 					웹서핑하며 간편하게 메모하세요
 				</Text>
 
@@ -136,7 +140,7 @@ export default function MemoScreen() {
 						onPress={() => setFilter("all")}
 					>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "all" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "all" ? "text-background" : "text-gray-500 dark:text-neutral-400"}`}
 						>
 							전체
 						</Text>
@@ -147,11 +151,11 @@ export default function MemoScreen() {
 					>
 						<Heart
 							size={12}
-							fill={filter === "wish" ? "#fff" : "#666"}
-							color={filter === "wish" ? "#fff" : "#666"}
+							fill={filter === "wish" ? (isDark ? "#111" : "#fff") : "#666"}
+							color={filter === "wish" ? (isDark ? "#111" : "#fff") : "#666"}
 						/>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "wish" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "wish" ? "text-background" : "text-gray-500 dark:text-neutral-400"}`}
 						>
 							위시리스트
 						</Text>
@@ -162,11 +166,11 @@ export default function MemoScreen() {
 					>
 						<Star
 							size={12}
-							fill={filter === "star" ? "#fff" : "#666"}
-							color={filter === "star" ? "#fff" : "#666"}
+							fill={filter === "star" ? (isDark ? "#111" : "#fff") : "#666"}
+							color={filter === "star" ? (isDark ? "#111" : "#fff") : "#666"}
 						/>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "star" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "star" ? "text-background" : "text-gray-500 dark:text-neutral-400"}`}
 						>
 							중요
 						</Text>
@@ -177,10 +181,10 @@ export default function MemoScreen() {
 					>
 						<BookOpen
 							size={12}
-							color={filter === "reading" ? "#fff" : "#666"}
+							color={filter === "reading" ? (isDark ? "#111" : "#fff") : "#666"}
 						/>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "reading" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "reading" ? "text-background" : "text-gray-500 dark:text-neutral-400"}`}
 						>
 							읽는 중
 						</Text>
@@ -231,13 +235,13 @@ export default function MemoScreen() {
 				) : (
 					<View className="items-center pt-[60px] gap-3">
 						{filter === "wish" ? (
-							<Heart size={48} color="#ddd" />
+							<Heart size={48} color={isDark ? "#444" : "#ddd"} />
 						) : filter === "star" ? (
-							<Star size={48} color="#ddd" />
+							<Star size={48} color={isDark ? "#444" : "#ddd"} />
 						) : filter === "reading" ? (
-							<BookOpen size={48} color="#ddd" />
+							<BookOpen size={48} color={isDark ? "#444" : "#ddd"} />
 						) : (
-							<Globe size={48} color="#ddd" />
+							<Globe size={48} color={isDark ? "#444" : "#ddd"} />
 						)}
 						<Text className="text-base font-semibold text-muted-foreground">
 							{filter === "wish"
@@ -248,7 +252,7 @@ export default function MemoScreen() {
 										? "읽는 중인 메모가 없습니다"
 										: "저장된 메모가 없습니다"}
 						</Text>
-						<Text className="text-[13px] text-gray-300">
+						<Text className="text-[13px] text-gray-300 dark:text-neutral-600">
 							{filter === "wish"
 								? "브라우저에서 마음에 드는 페이지를 저장해보세요"
 								: filter === "star"
@@ -261,7 +265,7 @@ export default function MemoScreen() {
 							className="mt-2 bg-foreground px-5 py-3 rounded-3xl"
 							onPress={() => router.navigate("/(main)/browser")}
 						>
-							<Text className="text-sm font-semibold text-white">
+							<Text className="text-sm font-semibold text-background">
 								{filter === "wish" || filter === "star" || filter === "reading"
 									? "브라우저에서 페이지 저장하기"
 									: "브라우저에서 웹서핑 시작하기"}

--- a/apps/app/app/(main)/settings/index.tsx
+++ b/apps/app/app/(main)/settings/index.tsx
@@ -13,6 +13,7 @@ import {
 	Switch,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -24,6 +25,7 @@ import {
 
 export default function SettingsScreen() {
 	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
 	const router = useRouter();
 	const { session, signOut, isLoggedIn } = useAuth();
 	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
@@ -43,7 +45,10 @@ export default function SettingsScreen() {
 	const appVersion = Constants.expoConfig?.version;
 
 	return (
-		<View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
+		<View
+			className="flex-1 bg-white dark:bg-neutral-950"
+			style={{ paddingTop: insets.top }}
+		>
 			<View className="px-5 pt-4 pb-4">
 				<Text className="text-[22px] font-extrabold text-foreground tracking-tight">
 					설정
@@ -61,7 +66,7 @@ export default function SettingsScreen() {
 							<>
 								<View className="flex-row items-center gap-3 mb-4">
 									<View className="w-10 h-10 rounded-full bg-foreground justify-center items-center">
-										<User size={20} color="#fff" />
+										<User size={20} color={isDark ? "#111" : "#fff"} />
 									</View>
 									<View className="flex-1">
 										<Text className="text-[15px] font-semibold text-foreground">
@@ -73,7 +78,7 @@ export default function SettingsScreen() {
 									</View>
 								</View>
 								<TouchableOpacity
-									className="flex-row items-center justify-center gap-2 py-2.5 rounded-[10px] border border-red-100 bg-red-50"
+									className="flex-row items-center justify-center gap-2 py-2.5 rounded-[10px] border border-red-100 dark:border-red-900/40 bg-red-50 dark:bg-red-950/30"
 									onPress={handleSignOut}
 								>
 									<LogOut size={16} color="#ef4444" />
@@ -87,8 +92,8 @@ export default function SettingsScreen() {
 								className="flex-row items-center justify-center gap-2 py-3 rounded-[10px] bg-foreground"
 								onPress={handleLogin}
 							>
-								<LogIn size={18} color="#fff" />
-								<Text className="text-[15px] font-semibold text-white">
+								<LogIn size={18} color={isDark ? "#111" : "#fff"} />
+								<Text className="text-[15px] font-semibold text-background">
 									로그인
 								</Text>
 							</TouchableOpacity>
@@ -168,13 +173,13 @@ export default function SettingsScreen() {
 							activeOpacity={0.6}
 						>
 							<View className="flex-row items-center gap-2">
-								<MessageCircle size={16} color="#555" />
+								<MessageCircle size={16} color={isDark ? "#aaa" : "#555"} />
 								<Text className="text-[15px] text-secondary-foreground">
 									문의하기
 								</Text>
 							</View>
 							<View className="flex-row items-center gap-2">
-								<ChevronRight size={14} color="#999" />
+								<ChevronRight size={14} color={isDark ? "#777" : "#999"} />
 							</View>
 						</TouchableOpacity>
 					</View>

--- a/apps/app/app/(main)/settings/index.tsx
+++ b/apps/app/app/(main)/settings/index.tsx
@@ -7,13 +7,13 @@ import {
 	MessageCircle,
 	User,
 } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import {
 	Alert,
 	Linking,
 	Switch,
 	Text,
 	TouchableOpacity,
-	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -22,14 +22,23 @@ import {
 	useSettingQuery,
 	useSettingUpsertMutation,
 } from "@/lib/hooks/useSetting";
+import { useThemePreference } from "@/lib/hooks/useThemePreference";
+import type { ThemePreference } from "@/lib/preferences/themePreference";
+
+const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
+	{ value: "system", label: "시스템 설정" },
+	{ value: "light", label: "라이트" },
+	{ value: "dark", label: "다크" },
+];
 
 export default function SettingsScreen() {
 	const insets = useSafeAreaInsets();
-	const isDark = useColorScheme() === "dark";
+	const isDark = useColorScheme().colorScheme === "dark";
 	const router = useRouter();
 	const { session, signOut, isLoggedIn } = useAuth();
 	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
 	const { mutate: upsertSetting } = useSettingUpsertMutation();
+	const { preference, setPreference } = useThemePreference();
 
 	const handleSignOut = () => {
 		Alert.alert("로그아웃", "로그아웃 하시겠습니까?", [
@@ -98,6 +107,31 @@ export default function SettingsScreen() {
 								</Text>
 							</TouchableOpacity>
 						)}
+					</View>
+				</View>
+
+				{/* Theme Section */}
+				<View className="mb-7">
+					<Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2.5">
+						화면 모드
+					</Text>
+					<View className="flex-row bg-card rounded-[14px] p-1 border border-muted">
+						{THEME_OPTIONS.map((option) => {
+							const isSelected = preference === option.value;
+							return (
+								<TouchableOpacity
+									key={option.value}
+									className={`flex-1 items-center py-2 rounded-xl ${isSelected ? "bg-foreground" : ""}`}
+									onPress={() => setPreference(option.value)}
+								>
+									<Text
+										className={`text-[13px] font-semibold ${isSelected ? "text-background" : "text-secondary-foreground"}`}
+									>
+										{option.label}
+									</Text>
+								</TouchableOpacity>
+							);
+						})}
 					</View>
 				</View>
 

--- a/apps/app/app/_layout.tsx
+++ b/apps/app/app/_layout.tsx
@@ -4,11 +4,13 @@ import { useShareIntent } from "expo-share-intent";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { Check } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 import { useEffect, useRef, useState } from "react";
 import { Text, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AuthProvider, useAuth } from "@/lib/auth/AuthProvider";
+import { useThemePreference } from "@/lib/hooks/useThemePreference";
 import { handleSharedUrl } from "@/lib/sharing/shareHandler";
 import { syncMemosToSupabase } from "@/lib/storage/syncService";
 import "../global.css";
@@ -106,6 +108,9 @@ function ShareIntentHandler() {
 }
 
 export default function RootLayout() {
+	useThemePreference();
+	const { colorScheme } = useColorScheme();
+
 	useEffect(() => {
 		SplashScreen.hideAsync();
 	}, []);
@@ -123,7 +128,7 @@ export default function RootLayout() {
 				</GestureHandlerRootView>
 				<SyncOnAuth />
 				<ShareIntentHandler />
-				<StatusBar style="dark" />
+				<StatusBar style={colorScheme === "dark" ? "light" : "dark"} />
 			</AuthProvider>
 		</QueryClientProvider>
 	);

--- a/apps/app/global.css
+++ b/apps/app/global.css
@@ -1,3 +1,43 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+	--background: 245 245 245;
+	--foreground: 17 17 17;
+	--primary: 17 17 17;
+	--primary-foreground: 255 255 255;
+	--secondary: 245 245 245;
+	--secondary-foreground: 85 85 85;
+	--muted: 240 240 240;
+	--muted-foreground: 153 153 153;
+	--accent: 124 58 237;
+	--accent-foreground: 255 255 255;
+	--destructive: 239 68 68;
+	--destructive-foreground: 255 255 255;
+	--border: 238 238 238;
+	--input: 245 245 245;
+	--card: 255 255 255;
+	--card-foreground: 17 17 17;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--background: 10 10 10;
+		--foreground: 245 245 245;
+		--primary: 245 245 245;
+		--primary-foreground: 17 17 17;
+		--secondary: 23 23 23;
+		--secondary-foreground: 212 212 212;
+		--muted: 38 38 38;
+		--muted-foreground: 163 163 163;
+		--accent: 167 139 250;
+		--accent-foreground: 17 17 17;
+		--destructive: 239 68 68;
+		--destructive-foreground: 255 255 255;
+		--border: 38 38 38;
+		--input: 38 38 38;
+		--card: 23 23 23;
+		--card-foreground: 245 245 245;
+	}
+}

--- a/apps/app/lib/hooks/useThemePreference.ts
+++ b/apps/app/lib/hooks/useThemePreference.ts
@@ -1,0 +1,29 @@
+import { useColorScheme } from "nativewind";
+import { useEffect, useState } from "react";
+import {
+	getThemePreference,
+	saveThemePreference,
+	type ThemePreference,
+} from "@/lib/preferences/themePreference";
+
+export function useThemePreference() {
+	const { setColorScheme } = useColorScheme();
+	const [preference, setPreference] = useState<ThemePreference>("system");
+
+	useEffect(() => {
+		getThemePreference().then((saved) => {
+			if (saved) {
+				setPreference(saved);
+				setColorScheme(saved);
+			}
+		});
+	}, [setColorScheme]);
+
+	const updatePreference = (next: ThemePreference) => {
+		setPreference(next);
+		setColorScheme(next);
+		saveThemePreference(next);
+	};
+
+	return { preference, setPreference: updatePreference };
+}

--- a/apps/app/lib/preferences/themePreference.ts
+++ b/apps/app/lib/preferences/themePreference.ts
@@ -1,0 +1,24 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const THEME_PREFERENCE_KEY = "webmemo:theme-preference";
+
+export type ThemePreference = "system" | "light" | "dark";
+
+export async function getThemePreference(): Promise<ThemePreference | null> {
+	try {
+		const value = await AsyncStorage.getItem(THEME_PREFERENCE_KEY);
+		return value === "light" || value === "dark" || value === "system"
+			? value
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export async function saveThemePreference(
+	preference: ThemePreference,
+): Promise<void> {
+	try {
+		await AsyncStorage.setItem(THEME_PREFERENCE_KEY, preference);
+	} catch {}
+}

--- a/apps/app/tailwind.config.js
+++ b/apps/app/tailwind.config.js
@@ -5,18 +5,36 @@ module.exports = {
 	theme: {
 		extend: {
 			colors: {
-				background: "#f5f5f5",
-				foreground: "#111111",
-				primary: { DEFAULT: "#111111", foreground: "#ffffff" },
-				secondary: { DEFAULT: "#f5f5f5", foreground: "#555555" },
-				muted: { DEFAULT: "#f0f0f0", foreground: "#999999" },
-				accent: { DEFAULT: "#7c3aed", foreground: "#ffffff" },
-				destructive: { DEFAULT: "#ef4444", foreground: "#ffffff" },
+				background: "rgb(var(--background) / <alpha-value>)",
+				foreground: "rgb(var(--foreground) / <alpha-value>)",
+				primary: {
+					DEFAULT: "rgb(var(--primary) / <alpha-value>)",
+					foreground: "rgb(var(--primary-foreground) / <alpha-value>)",
+				},
+				secondary: {
+					DEFAULT: "rgb(var(--secondary) / <alpha-value>)",
+					foreground: "rgb(var(--secondary-foreground) / <alpha-value>)",
+				},
+				muted: {
+					DEFAULT: "rgb(var(--muted) / <alpha-value>)",
+					foreground: "rgb(var(--muted-foreground) / <alpha-value>)",
+				},
+				accent: {
+					DEFAULT: "rgb(var(--accent) / <alpha-value>)",
+					foreground: "rgb(var(--accent-foreground) / <alpha-value>)",
+				},
+				destructive: {
+					DEFAULT: "rgb(var(--destructive) / <alpha-value>)",
+					foreground: "rgb(var(--destructive-foreground) / <alpha-value>)",
+				},
 				success: "#22c55e",
 				wish: "#ec4899",
-				border: "#eeeeee",
-				input: "#f5f5f5",
-				card: { DEFAULT: "#ffffff", foreground: "#111111" },
+				border: "rgb(var(--border) / <alpha-value>)",
+				input: "rgb(var(--input) / <alpha-value>)",
+				card: {
+					DEFAULT: "rgb(var(--card) / <alpha-value>)",
+					foreground: "rgb(var(--card-foreground) / <alpha-value>)",
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## 개요
앱 전체 다크모드 확장 + 설정 탭에서 라이트/다크/시스템 설정을 수동으로 고를 수 있는 기능 추가. 실기기 시뮬레이터에서 전체 화면 육안 확인 완료.

## 작업 사항
- tailwind.config.js/global.css를 CSS 변수 기반 시맨틱 토큰으로 전환해 대부분 화면이 자동으로 다크 대응되도록 함
- 탭바·메모 목록·설정·로그인·브라우저 빈 화면/즐겨찾기/블로그 시트의 남은 하드코딩 색상 수정
- `bg-foreground`(다크모드에서 흰색으로 반전)와 짝지어진 `text-white`/흰색 아이콘이 다크모드에서 안 보이던 버그 수정
- 설정 탭에 "화면 모드"(시스템 설정/라이트/다크) 섹션 추가, 선택값은 AsyncStorage에 저장되어 재시작 후에도 유지
- 아이콘 색상 로직에 쓰던 `react-native`의 `useColorScheme`을 `nativewind`의 것으로 전환(수동 오버라이드 반영을 위해 필요), 이 과정에서 `useColorScheme() === "dark"`처럼 객체를 문자열과 비교하던 버그도 함께 수정
- 상태바 스타일(`expo-status-bar`)도 다크모드에 맞춰 동적 전환

## 테스트
- `@web-memo/app` type-check 통과
- 변경 파일 biome check 통과(기존 TechBlogBottomSheet.tsx 사전 경고 4건은 무관)
- iOS 시뮬레이터에서 시스템 설정/라이트/다크 각각 실제 전환 확인, 메모 패널 포함 전 화면 스크린샷 검증
