### PR TITLE
[DB-838] ci: 자동 배포를 걷어내고 Actions 수동 릴리스 워크플로로 전환

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -2,12 +2,23 @@ name: CD - App (iOS Build)
 
 on:
   workflow_call:
+    inputs:
+      deploy_target:
+        description: "배포 대상 (none = 빌드만, production = TestFlight 제출)"
+        type: string
+        default: "none"
+      ref:
+        description: "체크아웃할 커밋/태그 (비우면 호출한 워크플로의 기본 ref)"
+        type: string
+        default: ""
 
 jobs:
   build-ios:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: pnpm/action-setup@v4
 
@@ -40,11 +51,11 @@ jobs:
           retention-days: 7
 
       - name: Write App Store Connect API key
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+        if: ${{ inputs.deploy_target == 'production' }}
         env:
           ASC_API_KEY_P8: ${{ secrets.EXPO_ASC_API_KEY_P8 }}
         run: echo "$ASC_API_KEY_P8" > apps/app/asc-api-key.p8
 
       - name: Submit to TestFlight
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+        if: ${{ inputs.deploy_target == 'production' }}
         run: cd apps/app && eas submit --platform ios --profile production --path ./build.ipa --non-interactive

--- a/.github/workflows/cd-extension.yml
+++ b/.github/workflows/cd-extension.yml
@@ -2,16 +2,27 @@ name: CD - Extension (Build + Chrome Store Upload)
 
 on:
   workflow_call:
+    inputs:
+      deploy_target:
+        description: "배포 대상 (none = 빌드만, production = 크롬 웹스토어 업로드)"
+        type: string
+        default: "none"
+      ref:
+        description: "체크아웃할 커밋/태그 (비우면 호출한 워크플로의 기본 ref)"
+        type: string
+        default: ""
 
 jobs:
   build-extension:
     runs-on: ubuntu-latest
     env:
-      WEB_URL: ${{ github.ref == 'refs/heads/develop' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
+      WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: pnpm/action-setup@v4
 
@@ -46,8 +57,8 @@ jobs:
   upload-extension:
     needs: build-extension
     runs-on: ubuntu-latest
-    name: Upload chrome store when push on master branch
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    name: Upload chrome store on production release
+    if: ${{ inputs.deploy_target == 'production' }}
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -2,14 +2,25 @@ name: CD - Web (Build + Vercel Deploy)
 
 on:
   workflow_call:
+    inputs:
+      deploy_target:
+        description: "배포 대상 (none = 빌드만, staging = 스테이징 배포, production = 프로덕션 배포)"
+        type: string
+        default: "none"
+      ref:
+        description: "체크아웃할 커밋/태그 (비우면 호출한 워크플로의 기본 ref)"
+        type: string
+        default: ""
 
 jobs:
   build-web:
     runs-on: ubuntu-latest
     env:
-      WEB_URL: ${{ github.ref == 'refs/heads/develop' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
+      WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: pnpm/action-setup@v4
 
@@ -47,14 +58,14 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: vercel build ${{ github.ref == 'refs/heads/master' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ inputs.deploy_target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy staging
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        if: ${{ inputs.deploy_target == 'staging' }}
         run: |
           VERCEL_DEPLOYED_URL="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
           vercel alias set "$VERCEL_DEPLOYED_URL" ${{ secrets.STAGING_WEB_URL_WITHOUT_PROTOCOL }} --token=${{ secrets.VERCEL_TOKEN }} --scope=gueit214s-projects
 
       - name: Deploy production
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ inputs.deploy_target == 'production' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 
 on:
   push:
@@ -94,20 +94,29 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
 
+  # 앱·확장은 CI에서 빌드 검증만 하고 배포하지 않습니다.
+  # 실제 배포(TestFlight 제출 / 웹스토어 업로드 / 웹 프로덕션)는 release.yml에서 수동으로 실행합니다.
   cd-app:
     needs: [ci, changes]
     if: needs.changes.outputs.app == 'true'
     uses: ./.github/workflows/cd-app.yml
     secrets: inherit
+    with:
+      deploy_target: "none"
 
   cd-extension:
     needs: [ci, changes]
     if: needs.changes.outputs.extension == 'true'
     uses: ./.github/workflows/cd-extension.yml
     secrets: inherit
+    with:
+      deploy_target: "none"
 
+  # 웹은 develop push일 때만 스테이징(테스트 서버)에 자동 배포합니다.
   cd-web:
     needs: [ci, changes]
     if: needs.changes.outputs.web == 'true'
     uses: ./.github/workflows/cd-web.yml
     secrets: inherit
+    with:
+      deploy_target: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/develop') && 'staging' || 'none' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      # turbo가 이벤트에서 읽은 base 브랜치명(예: master)은 체크아웃에 로컬 ref가
+      # 없어 해석에 실패하고, --affected가 "전부 변경됨"으로 폴백합니다.
+      # PR은 원격 추적 ref를, push는 직전 커밋을 기준으로 명시합니다.
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || github.event.before }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,23 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  release-new-version:
+    name: Release new version when push with `v*` tag
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      tag: ${{ github.ref_name }}
+    steps:
+      - run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${GITHUB_REPOSITORY#*/} ${tag#v}" \
+              --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,83 @@
-name: Release new Version
+name: Release
 
+# master 기준 수동 릴리스 워크플로. 체크한 타깃만 프로덕션으로 배포합니다.
+#
+# 버전업(package.json / Update.ts / translation.json)은 이 워크플로가 하지 않습니다.
+# 릴리스 노트는 사람이 써야 하므로 로컬 `/version-update`로 처리한 뒤 master PR로 머지하고,
+# 그 다음 이 워크플로를 실행하세요.
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
+    inputs:
+      app:
+        description: "앱 배포 (iOS 빌드 + TestFlight 제출)"
+        type: boolean
+        default: false
+      extension:
+        description: "확장 배포 (빌드 + 크롬 웹스토어 업로드, 게시는 수동)"
+        type: boolean
+        default: false
+      web:
+        description: "웹 배포 (Vercel 프로덕션)"
+        type: boolean
+        default: false
+      ref:
+        description: "배포할 커밋/태그 (비우면 워크플로를 실행한 브랜치의 최신 커밋)"
+        type: string
+        required: false
+        default: ""
 
-permissions:
-  contents: write
+# 릴리스가 동시에 두 번 돌지 않도록 직렬화합니다.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  release-new-version:
-    name: Release new version when push with `v*` tag
-    runs-on: ubuntu-22.04
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      tag: ${{ github.ref_name }}
+  # 타깃을 하나도 고르지 않으면 아무 잡도 돌지 않아 실행이 조용히 끝납니다.
+  # 그 경우를 명시적인 실패로 알립니다.
+  preflight:
+    name: 릴리스 대상 확인
+    runs-on: ubuntu-latest
     steps:
-      - run: |
-          gh release create "$tag" \
-              --repo="$GITHUB_REPOSITORY" \
-              --title="${GITHUB_REPOSITORY#*/} ${tag#v}" \
-              --generate-notes
+      - name: Check at least one target
+        env:
+          APP: ${{ inputs.app }}
+          EXTENSION: ${{ inputs.extension }}
+          WEB: ${{ inputs.web }}
+          REF: ${{ inputs.ref || github.ref_name }}
+        run: |
+          if [[ "$APP" != "true" && "$EXTENSION" != "true" && "$WEB" != "true" ]]; then
+            echo "::error::배포할 타깃을 하나 이상 선택하세요 (app / extension / web)"
+            exit 1
+          fi
+          echo "app=$APP extension=$EXTENSION web=$WEB"
+          echo "ref=$REF"
+
+  release-app:
+    name: 앱 릴리스
+    needs: preflight
+    if: ${{ inputs.app }}
+    uses: ./.github/workflows/cd-app.yml
+    secrets: inherit
+    with:
+      deploy_target: "production"
+      ref: ${{ inputs.ref }}
+
+  release-extension:
+    name: 확장 릴리스
+    needs: preflight
+    if: ${{ inputs.extension }}
+    uses: ./.github/workflows/cd-extension.yml
+    secrets: inherit
+    with:
+      deploy_target: "production"
+      ref: ${{ inputs.ref }}
+
+  release-web:
+    name: 웹 릴리스
+    needs: preflight
+    if: ${{ inputs.web }}
+    uses: ./.github/workflows/cd-web.yml
+    secrets: inherit
+    with:
+      deploy_target: "production"
+      ref: ${{ inputs.ref }}

--- a/docs/branch-strategy.md
+++ b/docs/branch-strategy.md
@@ -14,7 +14,9 @@ created from `master`, and only `master` accumulates permanent history.
 - The base branch for every other branch, including `develop`
 - The only branch that permanently accumulates history
 - Updated exclusively through pull requests from working branches
-- Pushing to `master` deploys production (see `.github/workflows/ci-cd.yml`)
+- Pushing to `master` only builds and verifies — it does **not** deploy
+  (see `.github/workflows/ci.yml`). Production deploys are triggered manually
+  (see [Releasing](#releasing))
 
 ### `develop`
 
@@ -66,6 +68,33 @@ git checkout feat/memo-search   # go back to the working branch
 
 Merging into `develop` does **not** finish the work. The working branch still
 needs its own pull request into `master`.
+
+### Releasing
+
+Merging into `master` never deploys anything. Releases are an explicit,
+separate action.
+
+1. **Bump the version on a working branch.** Run `/version-update` locally — it
+   writes the release notes (`Update.ts`, `ko`/`en` `translation.json`) and bumps
+   every `package.json`, then commits and pushes the `v*` tag. Open a PR into
+   `master` and merge it.
+   - The `v*` tag push creates a GitHub Release
+     (`.github/workflows/github-release.yml`).
+2. **Deploy the targets you want.** Actions → **Release** → *Run workflow*, then
+   check `app` / `extension` / `web`. Leave `ref` empty to deploy the latest
+   `master`, or pass a tag/commit to deploy that exact revision.
+   - `app` — iOS build + TestFlight submission
+   - `extension` — build + Chrome Web Store upload (publishing stays manual)
+   - `web` — Vercel production deploy
+3. **Reset `develop`** (below).
+
+| Trigger                | What runs                                          |
+| ---------------------- | -------------------------------------------------- |
+| PR (any branch)        | Lint, type-check, tests, and build verification     |
+| Push to `develop`      | The above + web deploy to the staging/test server   |
+| Push to `master`       | The above only — no deploy                          |
+| Actions → **Release**  | Production deploy of the checked targets            |
+| Push of a `v*` tag     | GitHub Release creation                             |
 
 ### Resetting `develop` (after a release)
 


### PR DESCRIPTION
## 배경

`master` 머지가 곧바로 프로덕션 배포(앱 TestFlight 제출 / 확장 웹스토어 업로드 / 웹 Vercel prod)로 이어지는 구조라, 코드를 머지하는 행위와 릴리스하는 행위가 분리되어 있지 않았습니다. 브랜치 전략을 master 기준으로 바꾼 #407에 이어, 배포도 "머지 시점"이 아니라 "원할 때 고른 타깃만" 나가도록 분리합니다.

## 변경 사항

### 1. CD 워크플로에 `deploy_target` · `ref` 입력 추가

`cd-app.yml` / `cd-extension.yml` / `cd-web.yml`이 `github.ref`로 배포 여부를 판단하던 것을, 호출자가 넘기는 입력으로 바꿨습니다.

| 입력 | 값 | 의미 |
| --- | --- | --- |
| `deploy_target` | `none` | 빌드/검증만 (기본값) |
| | `staging` | 웹 스테이징 배포 |
| | `production` | 프로덕션 배포 |
| `ref` | 커밋/태그 | 체크아웃할 리비전 (비우면 기본 ref) |

### 2. `ci-cd.yml` → `ci.yml` — 항상 빌드, 자동 배포는 develop 웹만

- PR·`master` 머지: 3개 타깃 모두 **빌드/검증까지만**
- `develop` push: 웹만 **스테이징 자동 배포** (기존 테스트 서버 흐름 유지)

진짜 CD가 `release.yml`로 빠졌으므로 파일명과 `name`을 역할에 맞게 `CI`로 정리했습니다. master 보호의 required status check 목록이 비어 있어(`contexts: []`) 이름 변경으로 깨지는 건 없습니다.

### 3. `release.yml` — 신규 수동 릴리스 워크플로

Actions → Release → Run workflow에서 `app` / `extension` / `web` 중 배포할 타깃을 체크해 실행합니다. `ref`를 비우면 실행한 브랜치의 최신 커밋을, 채우면 그 태그/커밋을 그대로 배포합니다. `concurrency: release`로 동시 실행을 막고, 타깃을 하나도 안 고르면 `preflight` 잡이 명시적으로 실패시킵니다.

**버전업은 이 워크플로가 하지 않습니다.** 릴리스 노트(`Update.ts`, ko/en `translation.json`)는 사람이 써야 하는 내용이라 워크플로가 대신할 수 없기 때문입니다. 기존대로 로컬 `/version-update` → master PR 머지로 처리하고, 그 다음 이 워크플로를 실행합니다.

기존 태그 트리거 워크플로(`v*` 태그 → GitHub Release 생성)는 이름만 `github-release.yml`로 바꿨고 동작은 그대로입니다.

### 4. `docs/branch-strategy.md` — 릴리스 절차 반영

"master 푸시가 프로덕션을 배포한다"는 서술이 더 이상 사실이 아니므로 바로잡고, 릴리스 절차와 트리거별 동작 표를 추가했습니다.

## 트리거별 동작

| 트리거 | 하는 일 |
| --- | --- |
| PR (모든 브랜치) | lint / type-check / test + 빌드 검증 |
| `develop` push | 위 + 웹 스테이징(테스트 서버) 배포 |
| `master` push | 위만 — 배포 없음 |
| Actions → Release | 체크한 타깃 프로덕션 배포 |
| `v*` 태그 push | GitHub Release 생성 |

## 테스트

- [x] `actionlint` 통과 (기존 `macos-26` 라벨 미인식 경고 1건 외 없음)
  - 재사용 워크플로 호출부의 입력 이름/타입까지 검증됨을 오탐 테스트로 확인 (없는 입력명을 넣으면 에러)
- [x] 이 PR의 CI 통과 — `ci` / `changes` 실행, `cd-*` 3개는 경로 필터로 스킵 (배포 스텝 없음)
- [ ] 머지 후 Actions → Release에서 `web`만 체크해 1회 실행 검증

> 참고: 작업 중 발견한 것 — GitHub은 **커밋 메시지 본문**에 `[skip ci]`가 있어도 워크플로 실행을 아예 생성하지 않습니다. 처음 푸시했을 때 커밋 본문에 이 문자열을 설명으로 적었다가 CI가 한 건도 안 돌아서 원인 파악에 시간을 썼습니다.
