### PR TITLE
[DB-838] chore: /pr 커맨드가 Draft PR을 생성하도록 변경

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,9 +1,9 @@
 ---
 name: pr
-description: 현재 커밋 작업사항을 바탕으로 master 대상 PR을 생성한다. 현재 브랜치가 master라면 /branch-new로 새 브랜치를 먼저 만든 뒤 PR을 올린다.
+description: 현재 커밋 작업사항을 바탕으로 master 대상 Draft PR을 생성한다. 현재 브랜치가 master라면 /branch-new로 새 브랜치를 먼저 만든 뒤 PR을 올린다.
 ---
 
-# /pr — 현재 작업을 master 대상 PR로 올리기
+# /pr — 현재 작업을 master 대상 Draft PR로 올리기
 
 > 이 파일은 전역 `~/.claude/commands/pr.md`를 **오버라이드**합니다.
 > 이 레포의 PR base는 `develop`이 아니라 `master`입니다.
@@ -25,12 +25,16 @@ description: 현재 커밋 작업사항을 바탕으로 master 대상 PR을 생�
 5. **모든 커밋**을 훑어서 PR 제목/본문을 작성한다 (최신 커밋만 보지 말 것).
    - 제목: 70자 이내의 짧고 명확한 한글 문장. 상세는 본문에.
    - 본문은 레포의 `PULL_REQUEST_TEMPLATE.md`를 따르며, HEREDOC으로 전달한다.
-6. `gh pr create --base master --title "..." --body "$(cat <<'EOF' ... EOF)"` 로 PR을 생성한다.
-7. 생성된 PR URL을 사용자에게 반환한다.
+6. `gh pr create --draft --base master --title "..." --body "$(cat <<'EOF' ... EOF)"` 로
+   **Draft PR**을 생성한다.
+7. 생성된 PR URL을 사용자에게 반환한다. 리뷰 준비가 되면 `gh pr ready <번호>`로
+   전환하면 된다는 것도 함께 안내한다.
 
 ## 주의
 
 - **base 브랜치는 항상 `master`**다. `--base develop`은 이 레포에서 금지다.
+- **PR은 항상 Draft로 생성**한다(`--draft`). 사용자가 명시적으로 "바로 리뷰 요청"이나
+  "ready로 올려줘"라고 하지 않는 한 예외 없다. Ready 전환은 사용자가 직접 판단한다.
 - **머지는 머지 커밋 방식**(`gh pr merge --merge`)이다. Squash & Merge와
   Rebase & Merge는 금지 — 개별 커밋 히스토리를 `master`에 보존한다.
 - `develop`에 이미 머지해서 테스트 서버에서 확인했더라도, 작업은 끝난 게 아니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 `/pr` 명령어는 다음을 수행합니다:
 - master 브랜치에서 새 브랜치 생성(이미 작업 브랜치면 생략)
 - 변경사항을 의미 있는 커밋 메시지로 커밋
-- 원격 푸시 후 master를 대상(base)으로 PR 생성 (머지는 Squash가 아닌 머지 커밋 방식)
+- 원격 푸시 후 master를 대상(base)으로 **Draft PR** 생성 (머지는 Squash가 아닌 머지 커밋 방식)
+
+**PR은 항상 Draft로 생성합니다**(`gh pr create --draft`). Ready 전환(`gh pr ready`)은
+사용자가 직접 판단하며, 명시적으로 요청받지 않는 한 자동으로 전환하지 않습니다.
 
 커밋/PR 제목·본문은 **항상 한글**, 브랜치명은 영문입니다. 자세한 규칙은 [AGENTS.md](AGENTS.md)의 "커밋 & PR 워크플로" 절을 따릅니다.
 


### PR DESCRIPTION
## 배경

`/pr`로 PR을 올리면 곧바로 Ready 상태가 되어 리뷰 대상이 됩니다. 올리자마자 CI 결과를 보거나 본문을 다듬는 경우가 많으므로, 기본을 Draft로 바꾸고 Ready 전환은 사람이 판단하도록 합니다.

## 변경 사항

- `.claude/commands/pr.md`
  - PR 생성 명령을 `gh pr create --draft --base master ...`로 변경
  - "PR은 항상 Draft로 생성" 규칙을 주의 항목에 명시. 사용자가 "바로 리뷰 요청" 등을 명시하지 않는 한 예외 없음
  - PR URL 반환 시 `gh pr ready <번호>`로 전환할 수 있다는 안내를 함께 하도록 추가
- `CLAUDE.md` — `/pr` 워크플로 설명에 Draft 생성 및 Ready 전환 주체를 반영

적용 범위는 이 레포입니다. 전역 `~/.claude/commands/pr.md`는 건드리지 않았습니다.

## 테스트

- [x] 이 PR 자체를 `--draft`로 생성해 동작 확인