### PR TITLE
fix: iOS 빌드 실패 수정 — 앱이 shared 배럴 대신 좁은 경로를 사용

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,21 @@ Turborepo 기반 모노레포입니다.
 **Testing & Infra**
 - `e2e/` — Playwright E2E 테스트 스위트
 
+### ⚠️ `apps/app`(React Native)에서 `@web-memo/shared` import 규칙
+
+**앱에서는 배럴 export(`@web-memo/shared/utils`)를 import하지 않습니다.**
+좁은 하위 경로(`@web-memo/shared/utils/url` 등)를 씁니다.
+
+`src/utils/index.ts`는 `Environment.ts`와 `Sentry.ts`를 재export하고, 이 둘은
+`@web-memo/env`를 import합니다. `@web-memo/env`는 `tsup`이 빌드 시점에 환경변수
+값을 인라인한 `dist/`만 노출하는데, `dist/`는 gitignore 대상이라 EAS 빌드
+샌드박스에 복사되지 않습니다. 그래서 Metro가 `@web-memo/env`를 해석하지 못하고
+**iOS 빌드가 실패**합니다. 웹/확장은 자체 번들러가 `dist/`를 갖고 있어 문제가
+드러나지 않으므로, 앱 빌드에서만 터집니다.
+
+필요한 심볼이 좁은 경로로 노출돼 있지 않다면 `packages/shared/package.json`의
+`exports`와 `typesVersions`에 하위 경로를 추가하세요.
+
 ### 확장 프로그램 진입점 (Manifest V3)
 
 - **Background Script**: 백그라운드 작업용 service worker

--- a/apps/app/app/(main)/browser/_hooks/useWebViewHighlights.ts
+++ b/apps/app/app/(main)/browser/_hooks/useWebViewHighlights.ts
@@ -3,7 +3,7 @@ import {
 	type HighlightItem,
 	toHighlightItem,
 } from "@web-memo/shared/modules/highlight";
-import { normalizeUrl } from "@web-memo/shared/utils";
+import { normalizeUrl } from "@web-memo/shared/utils/url";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useState } from "react";
 import type WebView from "react-native-webview";

--- a/apps/app/lib/hooks/useHighlightMutation.ts
+++ b/apps/app/lib/hooks/useHighlightMutation.ts
@@ -6,7 +6,7 @@ import {
 } from "@web-memo/shared/constants";
 import type { HighlightAnchor } from "@web-memo/shared/modules/highlight";
 import type { HighlightRow } from "@web-memo/shared/types";
-import { normalizeUrl } from "@web-memo/shared/utils";
+import { normalizeUrl } from "@web-memo/shared/utils/url";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { highlightService } from "@/lib/supabase/client";
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,6 +21,10 @@
 			"types": "./src/utils/Supabase.ts",
 			"default": "./src/utils/Supabase.ts"
 		},
+		"./utils/url": {
+			"types": "./src/utils/Url.ts",
+			"default": "./src/utils/Url.ts"
+		},
 		"./hooks": {
 			"types": "./src/hooks/index.ts",
 			"default": "./src/hooks/index.ts"
@@ -75,6 +79,9 @@
 			],
 			"utils/services": [
 				"./src/utils/Supabase.ts"
+			],
+			"utils/url": [
+				"./src/utils/Url.ts"
 			],
 			"hooks": [
 				"./src/hooks/index.ts"


### PR DESCRIPTION
## 배경

`cd-app / build-ios`가 **2026-08-16부터 8회 연속 실패**하고 있었습니다. 마지막 성공은 08-11(`d8bacea8`)입니다.

```
[EAGER_BUNDLE] Error: While trying to resolve module `@web-memo/env`
  from file `packages/shared/src/utils/Environment.ts`,
  the package `packages/shared/node_modules/@web-memo/env/package.json`
  was successfully found. However, this package itself specifies a
  `main` module field that could not be resolved (`.../@web-memo/env/index`)
```

## 원인

하이라이트 기능 작업(#406 등)에서 앱에 `@web-memo/shared/utils` import가 새로 생겼습니다. `normalizeUrl` 하나를 쓰기 위한 것이었는데, 이 배럴이 연쇄를 끌고 왔습니다.

```
apps/app/lib/hooks/useHighlightMutation.ts
  → packages/shared/src/utils/index.ts      (배럴)
  → packages/shared/src/utils/Sentry.ts
  → packages/shared/src/utils/Environment.ts
  → @web-memo/env                            ← Metro가 해석 실패
```

`@web-memo/env`는 `exports`로 `./dist/index.mjs`만 노출합니다. `tsup`이 **빌드 시점에 환경변수 값을 인라인**하는 구조라 소스가 아니라 `dist/`가 진짜 산출물입니다. 그런데 `dist/`는 `.gitignore`(`**/dist`) 대상이고 `.easignore`가 없어서, **EAS 빌드 샌드박스에 복사되지 않습니다.** Metro는 `exports` 해석에 실패하자 `main`으로 폴백했고, `main`이 없으니 기본값 `index`를 찾다가 죽었습니다.

웹(Next.js)과 확장(Vite)은 각자 빌드 환경에 `dist/`가 있어서 이 문제가 드러나지 않습니다. **앱 빌드에서만 터집니다.**

08-11에는 앱이 `@web-memo/shared/types`, `/constants`, `/utils/services`만 import했고, 이들 중 `@web-memo/env`로 이어지는 경로는 없었습니다.

## 변경 사항

`packages/shared/package.json`에 `./utils/url` 하위 경로를 추가하고(`exports` + `typesVersions`), 앱의 import 2곳을 옮겼습니다.

```diff
- import { normalizeUrl } from "@web-memo/shared/utils";
+ import { normalizeUrl } from "@web-memo/shared/utils/url";
```

`Url.ts`는 import가 하나도 없어 RN 번들에 안전합니다.

앱의 나머지 import 경로(`/constants`, `/types`, `/modules/highlight`, `/utils/services`)에는 `@web-memo/env`로 이어지는 경로가 없음을 확인했습니다.

`AGENTS.md`에 같은 실수가 반복되지 않도록 이유와 대처법을 기록했습니다.

## 테스트

`packages/env/dist`를 치워 **EAS 빌드 샌드박스와 동일한 조건**을 만든 뒤 실제로 Metro를 돌려 검증했습니다.

| 조건 | 결과 |
| --- | --- |
| 수정 전 + `dist` 없음 | ❌ CI와 **글자 그대로 동일한** 에러로 실패 |
| 수정 후 + `dist` 없음 | ✅ `iOS Bundled (3412 modules)` 성공 |
| 수정 후 + `dist` 있음 | ✅ 성공 (6.79 MB hbc) |

앱의 import 그래프를 정적으로 추적하는 스크립트로도 교차 확인했습니다 — 수정 전 `@web-memo/env` 도달 경로 2건, 수정 후 0건.

- [x] `pnpm exec turbo type-check` — 14/14 통과
- [x] `pnpm check` (biome) — 에러 0
- [x] `pnpm test:jest` — 16 파일 102 테스트 통과
- [x] `npx expo export --platform ios` — 번들 성공

## 남은 문제 (이 PR 범위 밖)

`expo doctor`도 실패하고 있습니다 — `expo` 54.0.33(요구 54.0.36) 등 패치 버전 7개 불일치. 빌드를 막는 원인은 아니지만 별도로 정리가 필요합니다.