### PR TITLE
[DB-844] CD 워크플로에 Android 빌드·제출 추가

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -1,10 +1,10 @@
-name: CD - App (iOS Build)
+name: CD - App (iOS / Android Build)
 
 on:
   workflow_call:
     inputs:
       deploy_target:
-        description: "배포 대상 (none = 빌드만, production = TestFlight 제출)"
+        description: "배포 대상 (none = 빌드만, production = 스토어 제출)"
         type: string
         default: "none"
       ref:
@@ -13,8 +13,24 @@ on:
         default: ""
 
 jobs:
-  build-ios:
-    runs-on: macos-26
+  build:
+    # iOS는 macOS 러너가 필수지만 Android는 ubuntu에서 돌려야 러너 과금이 절약됩니다.
+    # 빌드 전 단계(체크아웃~환경변수)가 두 플랫폼 동일해 matrix로 묶고,
+    # 플랫폼 전용 단계만 if로 분기합니다.
+    name: ${{ matrix.platform }} 빌드
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # 한쪽 플랫폼이 실패해도 나머지는 끝까지 돌려서 원인을 한 번에 봅니다.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ios
+            runner: macos-26
+            output: build.ipa
+          - platform: android
+            runner: ubuntu-latest
+            output: build.aab
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,6 +42,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+
+      # Gradle이 JDK 17을 요구합니다. ubuntu 러너의 기본 JDK 버전에 의존하지 않도록 명시합니다.
+      - name: Set up JDK
+        if: matrix.platform == 'android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
 
       - uses: expo/expo-github-action@v8
         with:
@@ -40,22 +64,31 @@ jobs:
           echo "${{ secrets.SHARED_ENV_FILE }}" >> packages/env/.env
           echo "${{ secrets.APP_ENV_FILE }}" >> apps/app/.env
 
-      - name: Build iOS
-        run: cd apps/app && eas build --platform ios --profile ci --local --non-interactive --output ./build.ipa
+      # 서명 키(iOS 인증서 / Android 키스토어)는 EAS 서버에 등록된 것을 받아 씁니다.
+      # 따라서 러너에는 EXPO_TOKEN 외에 별도 서명 시크릿이 필요 없습니다.
+      - name: Build ${{ matrix.platform }}
+        run: cd apps/app && eas build --platform ${{ matrix.platform }} --profile ci --local --non-interactive --output ./${{ matrix.output }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ios-build
-          path: apps/app/build.ipa
+          name: ${{ matrix.platform }}-build
+          path: apps/app/${{ matrix.output }}
           retention-days: 7
 
       - name: Write App Store Connect API key
-        if: ${{ inputs.deploy_target == 'production' }}
+        if: ${{ inputs.deploy_target == 'production' && matrix.platform == 'ios' }}
         env:
           ASC_API_KEY_P8: ${{ secrets.EXPO_ASC_API_KEY_P8 }}
         run: echo "$ASC_API_KEY_P8" > apps/app/asc-api-key.p8
 
-      - name: Submit to TestFlight
+      - name: Write Google Play service account key
+        if: ${{ inputs.deploy_target == 'production' && matrix.platform == 'android' }}
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.EXPO_ANDROID_SERVICE_ACCOUNT_JSON }}
+        run: echo "$PLAY_SERVICE_ACCOUNT_JSON" > apps/app/play-service-account.json
+
+      # iOS는 TestFlight, Android는 Play Console 내부 테스트 트랙으로 올라갑니다.
+      - name: Submit to store
         if: ${{ inputs.deploy_target == 'production' }}
-        run: cd apps/app && eas submit --platform ios --profile production --path ./build.ipa --non-interactive
+        run: cd apps/app && eas submit --platform ${{ matrix.platform }} --profile production --path ./${{ matrix.output }} --non-interactive

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       deploy_target:
-        description: "배포 대상 (none = 빌드만, production = 스토어 제출)"
+        description: "배포 대상 (none = 빌드 검증만, production = iOS TestFlight + Android Play 내부 테스트 제출)"
         type: string
         default: "none"
       ref:

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -19,6 +19,10 @@ jobs:
     # 플랫폼 전용 단계만 if로 분기합니다.
     name: ${{ matrix.platform }} 빌드
     runs-on: ${{ matrix.runner }}
+    env:
+      # 릴리스만 빌드 번호를 올립니다(ci). PR 검증 빌드는 버려지는 산출물이라
+      # 번호를 올리면 안 되므로 autoIncrement만 끈 verify 프로파일을 씁니다.
+      BUILD_PROFILE: ${{ inputs.deploy_target == 'production' && 'ci' || 'verify' }}
     strategy:
       # 한쪽 플랫폼이 실패해도 나머지는 끝까지 돌려서 원인을 한 번에 봅니다.
       fail-fast: false
@@ -67,7 +71,7 @@ jobs:
       # 서명 키(iOS 인증서 / Android 키스토어)는 EAS 서버에 등록된 것을 받아 씁니다.
       # 따라서 러너에는 EXPO_TOKEN 외에 별도 서명 시크릿이 필요 없습니다.
       - name: Build ${{ matrix.platform }}
-        run: cd apps/app && eas build --platform ${{ matrix.platform }} --profile ci --local --non-interactive --output ./${{ matrix.output }}
+        run: cd apps/app && eas build --platform ${{ matrix.platform }} --profile "$BUILD_PROFILE" --local --non-interactive --output ./${{ matrix.output }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/**"
 
+# 같은 브랜치에 연속으로 푸시하면 이전 run을 취소해 중복 빌드를 막습니다.
+# 다만 master는 run에 배포가 걸려 있어 중간에 끊기면 안 되므로 취소하지 않고,
+# 대신 직렬로 줄을 세워 제출이 동시에 두 번 나가지 않게 합니다.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,16 +98,20 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
 
-  # 앱·확장은 CI에서 빌드 검증만 하고 배포하지 않습니다.
-  # 실제 배포(TestFlight 제출 / 웹스토어 업로드 / 웹 프로덕션)는 release.yml에서 수동으로 실행합니다.
+  # 앱은 master push(= PR 머지)일 때 테스트 배포까지 자동으로 진행합니다.
+  # iOS는 TestFlight, Android는 Play 내부 테스트 트랙으로 올라가며 둘 다 스토어
+  # 정식 출시가 아니라 테스터 대상 배포입니다. 정식 출시 승격은 수동으로 합니다.
+  # PR에서는 빌드 검증만 하고(none) 제출하지 않습니다.
   cd-app:
     needs: [ci, changes]
     if: needs.changes.outputs.app == 'true'
     uses: ./.github/workflows/cd-app.yml
     secrets: inherit
     with:
-      deploy_target: "none"
+      deploy_target: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') && 'production' || 'none' }}
 
+  # 확장은 CI에서 빌드 검증만 하고 배포하지 않습니다.
+  # 웹스토어 업로드는 release.yml에서 수동으로 실행합니다.
   cd-extension:
     needs: [ci, changes]
     if: needs.changes.outputs.extension == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       app:
-        description: "앱 배포 (iOS 빌드 + TestFlight 제출)"
+        description: "앱 배포 (iOS → TestFlight, Android → Play 내부 테스트)"
         type: boolean
         default: false
       extension:

--- a/apps/app/.gitignore
+++ b/apps/app/.gitignore
@@ -9,6 +9,8 @@ dist/
 *.key
 *.mobileprovision
 *.ipa
+*.aab
+play-service-account.json
 *.orig.*
 web-build/
 

--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -20,6 +20,10 @@
 			"env": {
 				"NODE_ENV": "production"
 			}
+		},
+		"verify": {
+			"extends": "ci",
+			"autoIncrement": false
 		}
 	},
 	"submit": {

--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -29,6 +29,11 @@
 				"ascApiKeyId": "HT774VM4W5",
 				"ascApiKeyIssuerId": "ab5c73bd-ddb0-44a7-9797-941c1a211615",
 				"ascAppId": "6759237784"
+			},
+			"android": {
+				"serviceAccountKeyPath": "./play-service-account.json",
+				"track": "internal",
+				"releaseStatus": "completed"
 			}
 		}
 	}


### PR DESCRIPTION
## 요약

- iOS 전용이던 `cd-app.yml`을 matrix 잡으로 전환해 **Android를 함께 빌드**합니다.
- **master 머지 시 TestFlight·Play 내부 테스트로 자동 제출**되도록 했습니다. 더 이상 워크플로를 수동으로 누를 필요가 없습니다.
- PR 검증 빌드가 빌드 번호를 소모하던 문제를 `verify` 프로파일 분리로 고쳤습니다.

## 배경

앱은 이미 Android를 지원합니다. `app.json`에 `android.package`·adaptiveIcon·intentFilters가 있고, Android 전용 config plugin(`withKakaoMavenRepo`, `withAndroidGradleMemory`)과 `google-play-assets/`까지 준비돼 있었습니다. CD 파이프라인만 iOS를 태우고 있었습니다.

## 변경사항

**`.github/workflows/cd-app.yml`**
- `build-ios` → `build` matrix 잡 (`ios`/`macos-26`/`build.ipa`, `android`/`ubuntu-latest`/`build.aab`)
- `fail-fast: false` — 한쪽이 깨져도 나머지는 끝까지 확인
- Android에만 `actions/setup-java@v4`(temurin 17). ubuntu 러너 기본 JDK에 의존하지 않도록 명시
- 아티팩트를 `ios-build`/`android-build`로 분리
- 빌드 프로파일을 `deploy_target`에 따라 선택 (`BUILD_PROFILE` env)

**`.github/workflows/ci.yml`**
- master push(= PR 머지)일 때 `deploy_target: production`을 넘겨 자동 제출. PR은 `none` 유지
- 브랜치별 `concurrency` 추가. 작업 브랜치는 이전 run 취소, master는 취소 없이 직렬화

**`apps/app/eas.json`**
- `submit.production.android` 추가 (`track: internal`, `releaseStatus: completed`)
- `verify` 빌드 프로파일 추가 — `ci`를 extends하고 `autoIncrement`만 off

**`apps/app/.gitignore`**
- `*.aab`, `play-service-account.json` 추가

## 동작 방식

| 상황 | deploy_target | 프로파일 | 결과 |
|---|---|---|---|
| PR 푸시 | `none` | `verify` | 빌드 검증만, 빌드 번호 소모 없음 |
| master 머지 | `production` | `ci` | TestFlight + Play 내부 테스트 자동 제출 |
| `release.yml` 수동 | `production` | `ci` | 특정 ref 재배포용 |

정식 출시(App Store 심사 / Play 프로덕션 승격)는 **자동화하지 않았습니다.** 머지만으로 실사용자에게 배포되면 위험하므로 콘솔에서 수동으로 합니다.

## 서명 키 관리

iOS가 이미 `EXPO_TOKEN`만으로 `--local` 빌드를 돌고 있어(인증서 시크릿 없음) EAS 원격 credential 방식이 확립돼 있었습니다. Android도 동일하게 맞췄습니다. 키스토어를 시크릿으로 넣으면 관리 지점이 둘로 갈라지기 때문입니다.

EAS 조회 결과 Android 키스토어는 keystore 본체·keyAlias·keyPassword·keystorePassword가 모두 등록돼 있어 **추가 서명 시크릿이 필요 없습니다.**

## 검증 완료

- [x] CI에서 Android 빌드 통과 (26분, ubuntu-latest)
- [x] iOS 빌드 회귀 없음 (16분, macos-26)
- [x] `verify` 프로파일 적용 확인 — 로그의 `BUILD_PROFILE: verify`, 원격 versionCode 미증가
- [x] `eas config`로 프로파일 해석값 대조 — verify는 `autoIncrement=false`, ci는 `true`, 나머지 동일
- [x] 서비스 계정 키 등록 및 Play API 실측 검증 — 토큰 발급 / API 활성화 / 앱 접근 권한 모두 통과
- [x] **로컬 `eas submit`으로 Play 내부 테스트 제출 성공** — versionCode 13이 internal 트랙에 반영됨

## 필요한 시크릿

`EXPO_ANDROID_SERVICE_ACCOUNT_JSON` — **등록 완료** (`web-memo@page-memos.iam.gserviceaccount.com`)

## Test plan

- [ ] 머지 후 master에서 자동 제출이 도는지 확인
- [ ] TestFlight에 새 빌드가 올라오는지 확인
- [ ] Play 내부 테스트 트랙에 versionCode가 증가해 올라오는지 확인