### PR TITLE
fix: 앱 웹뷰에서 드래그 시 메모 자동 복사되는 동작 제거

### DIFF
--- a/apps/app/app/(main)/browser/_components/MemoPanel.tsx
+++ b/apps/app/app/(main)/browser/_components/MemoPanel.tsx
@@ -26,9 +26,6 @@ interface MemoPanelProps {
 	pageTitle: string;
 	favIconUrl?: string;
 	onClose?: () => void;
-	/** 웹뷰에서 드래그로 선택된 텍스트. 값이 바뀔 때마다 메모에 자동으로 덧붙인다 */
-	selectedText?: string | null;
-	onSelectedTextConsumed?: () => void;
 }
 
 export function MemoPanel({
@@ -36,8 +33,6 @@ export function MemoPanel({
 	pageTitle,
 	favIconUrl,
 	onClose,
-	selectedText,
-	onSelectedTextConsumed,
 }: MemoPanelProps) {
 	const { isLoggedIn } = useAuth();
 	const isDark = useColorScheme() === "dark";
@@ -99,12 +94,6 @@ export function MemoPanel({
 		pageTitle,
 		url,
 	]);
-
-	useEffect(() => {
-		if (!selectedText) return;
-		setMemoText((prev) => (prev ? `${prev}\n${selectedText}` : selectedText));
-		onSelectedTextConsumed?.();
-	}, [selectedText, onSelectedTextConsumed]);
 
 	// 설정을 꺼도 이미 작성된 내용이 있으면 유실로 오해하지 않도록 계속 노출한다.
 	const isImpressionSectionVisible =

--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -89,7 +89,6 @@ export function useBrowserState({
 	const [contentHeight, setContentHeight] = useState(0);
 	const [wishToast, setWishToast] = useState<string | null>(null);
 	const [savedRatio, setSavedRatio] = useState(DEFAULT_PANEL_RATIO);
-	const [selectedText, setSelectedText] = useState<string | null>(null);
 	const [isActionsSheetOpen, setIsActionsSheetOpen] = useState(false);
 	const [isAISheetOpen, setIsAISheetOpen] = useState(false);
 	const [aiPageText, setAiPageText] = useState("");
@@ -509,9 +508,6 @@ export function useBrowserState({
 				} else if (message.type === "scroll") {
 					persistScrollPosition(message.scrollY, message.maxY ?? 0);
 					handleScrollMessage(message.direction, message.scrollY);
-				} else if (message.type === "textSelected" && message.text) {
-					setSelectedText(message.text);
-					if (!isMemoOpen) openPanel();
 				} else if (message.type === "pageTextExtracted") {
 					const text = message.text ?? "";
 					setAiPageText(text);
@@ -532,16 +528,10 @@ export function useBrowserState({
 		[
 			handleScrollMessage,
 			persistScrollPosition,
-			isMemoOpen,
-			openPanel,
 			requestArticleAI,
 			onHighlightMessage,
 		],
 	);
-
-	const consumeSelectedText = useCallback(() => {
-		setSelectedText(null);
-	}, []);
 
 	const openAISheet = useCallback(() => {
 		setIsAISheetOpen(true);
@@ -654,8 +644,6 @@ export function useBrowserState({
 		handleBlogSelect,
 		handleShare,
 		SCROLL_DETECT_JS,
-		selectedText,
-		consumeSelectedText,
 		isActionsSheetOpen,
 		setIsActionsSheetOpen,
 		isAISheetOpen,

--- a/apps/app/app/(main)/browser/_utils/webViewScripts.ts
+++ b/apps/app/app/(main)/browser/_utils/webViewScripts.ts
@@ -59,24 +59,6 @@ export const SCROLL_DETECT_JS = `
 })(); true;
 `;
 
-/** 텍스트 드래그 선택 감지 후 postMessage로 전달 (선택 종료 시 메모에 자동 기입용) */
-export const TEXT_SELECT_JS = `
-(function() {
-  if (window.__webmemoSelectSetup) return;
-  window.__webmemoSelectSetup = true;
-  var debounceTimer = null;
-  document.addEventListener('selectionchange', function() {
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(function() {
-      var text = (window.getSelection() || '').toString().trim();
-      if (text.length > 1) {
-        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'textSelected', text: text }));
-      }
-    }, 400);
-  });
-})(); true;
-`;
-
 /** 현재 페이지 본문 텍스트를 추출해 postMessage로 전달 (AI 요약/질의응답용) */
 export const EXTRACT_PAGE_TEXT_JS = `
 (function() {
@@ -90,7 +72,7 @@ export const EXTRACT_PAGE_TEXT_JS = `
 `;
 
 /** 네비게이션 완료 시 injectJavaScript로 주입할 전체 스크립트 */
-export const INJECTED_JS_ON_NAVIGATION = `${FAVICON_EXTRACT_JS}\n${SCROLL_DETECT_JS}\n${TEXT_SELECT_JS}\n${HIGHLIGHT_SCRIPT}\ntrue;`;
+export const INJECTED_JS_ON_NAVIGATION = `${FAVICON_EXTRACT_JS}\n${SCROLL_DETECT_JS}\n${HIGHLIGHT_SCRIPT}\ntrue;`;
 
 /** WebView 최초 로드 시 주입할 스크립트 */
 export const INJECTED_JS_ON_LOAD = `${SCROLL_DETECT_JS}\n${HIGHLIGHT_SCRIPT}\ntrue;`;

--- a/apps/app/app/(main)/browser/index.tsx
+++ b/apps/app/app/(main)/browser/index.tsx
@@ -71,8 +71,6 @@ export default function BrowserScreen() {
 		handleBlogSelect,
 		handleShare,
 		SCROLL_DETECT_JS,
-		selectedText,
-		consumeSelectedText,
 		isActionsSheetOpen,
 		setIsActionsSheetOpen,
 		isAISheetOpen,
@@ -178,8 +176,6 @@ export default function BrowserScreen() {
 						pageTitle={pageTitle}
 						favIconUrl={pageFavIconUrl}
 						onClose={closePanel}
-						selectedText={selectedText}
-						onSelectedTextConsumed={consumeSelectedText}
 					/>
 				</Animated.View>
 			</View>


### PR DESCRIPTION
## 요약

- 앱 웹뷰에서 텍스트를 드래그하면 하이라이팅 메뉴가 뜨는 동시에 메모 패널이 자동으로 열리고 선택 텍스트가 메모 본문에 덧붙여져, 하이라이팅과 메모 복사 기능이 중복 동작하던 문제를 해결했습니다.
- `selectionchange`를 감지해 `textSelected` 메시지를 보내던 `TEXT_SELECT_JS`를 삭제하고, 이를 받아 처리하던 상태(`selectedText`)·핸들러·`MemoPanel` props를 함께 정리했습니다.
- 드래그 시에는 하이라이팅(`HIGHLIGHT_SCRIPT`)만 동작합니다.

## 변경 파일

- `apps/app/app/(main)/browser/_utils/webViewScripts.ts` — `TEXT_SELECT_JS` 삭제, `INJECTED_JS_ON_NAVIGATION`에서 제외
- `apps/app/app/(main)/browser/_hooks/useBrowserState.ts` — `selectedText` 상태, `textSelected` 메시지 분기, `consumeSelectedText` 제거
- `apps/app/app/(main)/browser/index.tsx` — `MemoPanel`에 넘기던 관련 props 제거
- `apps/app/app/(main)/browser/_components/MemoPanel.tsx` — 선택 텍스트를 메모에 덧붙이던 `useEffect`와 props 제거

## 참고

- 기존에 `textSelected` 수신 시 메모 패널을 자동으로 열던 동작도 함께 사라집니다. 패널은 FAB·토글로만 엽니다.

## 테스트 체크리스트

- [ ] 웹뷰에서 텍스트 드래그 시 하이라이팅 메뉴만 뜨고 메모 패널이 열리지 않는다
- [ ] 드래그한 텍스트가 메모 본문에 자동으로 들어가지 않는다
- [ ] 하이라이팅 생성/수정/삭제가 기존대로 동작한다
- [ ] FAB·토글로 메모 패널 열기/닫기 및 저장이 정상 동작한다
- [ ] `pnpm type-check`, `pnpm lint` 통과