### PR TITLE
feat: 앱에서 라이트/다크 테마를 직접 고르는 설정 추가

### DIFF
--- a/apps/app/app/(auth)/login/_components/SocialLoginButton.tsx
+++ b/apps/app/app/(auth)/login/_components/SocialLoginButton.tsx
@@ -1,4 +1,4 @@
-import { Text, TouchableOpacity } from "react-native";
+import { Text, TouchableOpacity, useColorScheme } from "react-native";
 import { AppleIcon, GoogleIcon, KakaoIcon } from "./icons";
 
 interface SocialLoginButtonProps {
@@ -41,6 +41,10 @@ export function SocialLoginButton({
 }: SocialLoginButtonProps) {
 	const config = PROVIDER_CONFIG[provider];
 	const Icon = config.icon;
+	const isDark = useColorScheme() === "dark";
+
+	// 검정 배경인 Apple 버튼은 다크 테마에서 화면 배경과 붙어버리므로 테두리로 경계를 만든다.
+	const isBorderlessOnDark = isDark && provider === "apple";
 
 	return (
 		<TouchableOpacity
@@ -48,8 +52,8 @@ export function SocialLoginButton({
 			style={[
 				{
 					backgroundColor: config.backgroundColor,
-					borderColor: config.borderColor,
-					borderWidth: config.borderWidth,
+					borderColor: isBorderlessOnDark ? "#3f3f46" : config.borderColor,
+					borderWidth: isBorderlessOnDark ? 1 : config.borderWidth,
 					shadowColor: "#000",
 					shadowOffset: { width: 0, height: 2 },
 					shadowOpacity: 0.1,

--- a/apps/app/app/(auth)/login/index.tsx
+++ b/apps/app/app/(auth)/login/index.tsx
@@ -36,7 +36,7 @@ export default function LoginScreen() {
 	};
 
 	return (
-		<SafeAreaView className="flex-1 bg-white">
+		<SafeAreaView className="flex-1 bg-white dark:bg-neutral-950">
 			<View className="flex-1 justify-center px-8">
 				<View className="items-center mb-10 gap-3">
 					<Image
@@ -44,8 +44,10 @@ export default function LoginScreen() {
 						style={{ width: 64, height: 64 }}
 						resizeMode="contain"
 					/>
-					<Text className="text-2xl font-bold text-foreground">웹 메모</Text>
-					<Text className="text-sm text-gray-500 text-center">
+					<Text className="text-2xl font-bold text-foreground dark:text-white">
+						웹 메모
+					</Text>
+					<Text className="text-sm text-gray-500 dark:text-neutral-400 text-center">
 						아티클 읽으며 간편하게 메모하세요.
 					</Text>
 				</View>

--- a/apps/app/app/(main)/_components/CustomTabBar.tsx
+++ b/apps/app/app/(main)/_components/CustomTabBar.tsx
@@ -5,7 +5,13 @@ import {
 	type LucideIcon,
 	Settings,
 } from "lucide-react-native";
-import { Platform, Text, TouchableOpacity, View } from "react-native";
+import {
+	Platform,
+	Text,
+	TouchableOpacity,
+	useColorScheme,
+	View,
+} from "react-native";
 import Animated, {
 	useAnimatedStyle,
 	useSharedValue,
@@ -36,6 +42,7 @@ export function CustomTabBar({
 	const { tabBarTranslateY, isBrowserActive } = useBrowserScroll();
 	const barHeight = useSharedValue(0);
 	const { isKeyboardVisible } = useKeyboardHeight();
+	const isDark = useColorScheme() === "dark";
 
 	const wrapperStyle = useAnimatedStyle(() => {
 		if (isBrowserActive.value !== 1 || barHeight.value === 0) return {};
@@ -52,10 +59,13 @@ export function CustomTabBar({
 		return null;
 	}
 
+	const focusedIconColor = isDark ? "#fff" : "#111";
+	const unfocusedIconColor = isDark ? "#737373" : "#999";
+
 	return (
 		<Animated.View style={wrapperStyle}>
 			<View
-				className="flex-row bg-white border-t border-border pt-2"
+				className="flex-row bg-white dark:bg-neutral-900 border-t border-border dark:border-neutral-800 pt-2"
 				style={{ paddingBottom: insets.bottom }}
 				onLayout={(e) => {
 					if (barHeight.value === 0) {
@@ -88,9 +98,12 @@ export function CustomTabBar({
 							className="flex-1 items-center justify-center py-1 gap-0.5"
 							activeOpacity={0.7}
 						>
-							<Icon size={22} color={isFocused ? "#111" : "#999"} />
+							<Icon
+								size={22}
+								color={isFocused ? focusedIconColor : unfocusedIconColor}
+							/>
 							<Text
-								className={`text-[11px] mt-0.5 ${isFocused ? "text-foreground font-semibold" : "text-muted-foreground"}`}
+								className={`text-[11px] mt-0.5 ${isFocused ? "text-foreground dark:text-white font-semibold" : "text-muted-foreground dark:text-neutral-500"}`}
 							>
 								{config.label}
 							</Text>

--- a/apps/app/app/(main)/_components/TodayArticles.tsx
+++ b/apps/app/app/(main)/_components/TodayArticles.tsx
@@ -32,7 +32,7 @@ export function TodayArticles({ onPressArticle }: TodayArticlesProps) {
 		<View className="mb-4">
 			<View className="flex-row items-center gap-1.5 mb-2.5">
 				<BookOpen size={16} color="#a855f7" />
-				<Text className="text-[15px] font-bold text-foreground">
+				<Text className="text-[15px] font-bold text-foreground dark:text-white">
 					오늘 읽을 아티클
 				</Text>
 			</View>
@@ -40,7 +40,7 @@ export function TodayArticles({ onPressArticle }: TodayArticlesProps) {
 				{todayArticleList.map((memo) => (
 					<TouchableOpacity
 						key={memo.id}
-						className="flex-row items-center gap-2.5 rounded-xl border-2 border-muted bg-card px-3.5 py-3"
+						className="flex-row items-center gap-2.5 rounded-xl border-2 border-muted dark:border-neutral-800 bg-card dark:bg-neutral-900 px-3.5 py-3"
 						onPress={() => onPressArticle(memo.url)}
 						activeOpacity={0.7}
 					>
@@ -53,7 +53,7 @@ export function TodayArticles({ onPressArticle }: TodayArticlesProps) {
 							<BookOpen size={20} color="#9ca3af" />
 						)}
 						<Text
-							className="flex-1 text-sm text-secondary-foreground"
+							className="flex-1 text-sm text-secondary-foreground dark:text-neutral-300"
 							numberOfLines={1}
 						>
 							{memo.title}

--- a/apps/app/app/(main)/browser/_components/EmptyBrowserView.tsx
+++ b/apps/app/app/(main)/browser/_components/EmptyBrowserView.tsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react-native";
-import { ScrollView, TextInput, View } from "react-native";
+import { ScrollView, TextInput, useColorScheme, View } from "react-native";
 import type { EdgeInsets } from "react-native-safe-area-context";
 import { FavoriteLinks } from "./FavoriteLinks";
 import { TechBlogLinks } from "./TechBlogLinks";
@@ -19,19 +19,24 @@ export function EmptyBrowserView({
 	onUrlSubmit,
 	onSelectBlog,
 }: EmptyBrowserViewProps) {
+	const isDark = useColorScheme() === "dark";
+
 	return (
-		<View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
+		<View
+			className="flex-1 bg-white dark:bg-neutral-950"
+			style={{ paddingTop: insets.top }}
+		>
 			<ScrollView className="flex-1 pt-4" keyboardShouldPersistTaps="handled">
 				<View className="px-5">
-					<View className="flex-row items-center bg-input rounded-[14px] px-3.5 py-3 gap-2.5">
-						<Search size={18} color="#999" />
+					<View className="flex-row items-center bg-input dark:bg-neutral-800 rounded-[14px] px-3.5 py-3 gap-2.5">
+						<Search size={18} color={isDark ? "#737373" : "#999"} />
 						<TextInput
-							className="flex-1 text-base text-[#333] p-0"
+							className="flex-1 text-base text-[#333] dark:text-white p-0"
 							value={urlInput}
 							onChangeText={onUrlInputChange}
 							onSubmitEditing={onUrlSubmit}
 							placeholder="검색어를 입력하세요"
-							placeholderTextColor="#999"
+							placeholderTextColor={isDark ? "#666" : "#999"}
 							autoCapitalize="none"
 							autoCorrect={false}
 							keyboardType="default"

--- a/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/FavoriteLinks.tsx
@@ -6,6 +6,7 @@ import {
 	Image,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useFavoriteRemove, useFavorites } from "@/lib/hooks/useFavorites";
@@ -17,16 +18,17 @@ interface FavoriteLinksProps {
 export function FavoriteLinks({ onSelectUrl }: FavoriteLinksProps) {
 	const { data: favorites } = useFavorites();
 	const removeFavorite = useFavoriteRemove();
+	const isDark = useColorScheme() === "dark";
 
 	if (!favorites || favorites.length === 0) {
 		return (
 			<View className="mt-7 px-5">
-				<Text className="text-base font-bold text-foreground mb-3">
+				<Text className="text-base font-bold text-foreground dark:text-white mb-3">
 					즐겨찾기
 				</Text>
-				<View className="items-center py-6 bg-card rounded-xl border border-border">
-					<Bookmark size={24} color="#ddd" />
-					<Text className="text-[13px] text-muted-foreground mt-2">
+				<View className="items-center py-6 bg-card dark:bg-neutral-900 rounded-xl border border-border dark:border-neutral-800">
+					<Bookmark size={24} color={isDark ? "#404040" : "#ddd"} />
+					<Text className="text-[13px] text-muted-foreground dark:text-neutral-500 mt-2">
 						자주 방문하는 페이지를 즐겨찾기에 추가해보세요
 					</Text>
 				</View>
@@ -52,7 +54,9 @@ export function FavoriteLinks({ onSelectUrl }: FavoriteLinksProps) {
 	return (
 		<View className="mt-7">
 			<View className="flex-row justify-between items-center mb-4 px-5">
-				<Text className="text-base font-bold text-foreground">즐겨찾기</Text>
+				<Text className="text-base font-bold text-foreground dark:text-white">
+					즐겨찾기
+				</Text>
 			</View>
 			<FlatList
 				data={favorites}
@@ -94,7 +98,7 @@ function FavoriteItem({
 			onLongPress={() => onLongPress(item.url, item.title || domain)}
 			activeOpacity={0.7}
 		>
-			<View className="w-14 h-14 rounded-[14px] bg-input justify-center items-center overflow-hidden">
+			<View className="w-14 h-14 rounded-[14px] bg-input dark:bg-neutral-800 justify-center items-center overflow-hidden">
 				{item.favIconUrl && !imgError ? (
 					<Image
 						source={{ uri: item.favIconUrl }}
@@ -104,17 +108,17 @@ function FavoriteItem({
 					/>
 				) : (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{(domain || "?").charAt(0).toUpperCase()}
 						</Text>
 					</View>
 				)}
 			</View>
 			<Text
-				className="text-[11px] text-secondary-foreground text-center leading-[14px]"
+				className="text-[11px] text-secondary-foreground dark:text-neutral-400 text-center leading-[14px]"
 				numberOfLines={1}
 			>
 				{domain || item.title}

--- a/apps/app/app/(main)/browser/_components/HighlightEditSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/HighlightEditSheet.tsx
@@ -17,6 +17,7 @@ import {
 	Text,
 	TextInput,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -63,6 +64,7 @@ export function HighlightEditSheet({
 	onDelete,
 }: HighlightEditSheetProps) {
 	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
@@ -192,14 +194,14 @@ export function HighlightEditSheet({
 				</Animated.View>
 
 				<Animated.View
-					className="bg-white rounded-t-[20px]"
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
 					style={[
 						sheetStyle,
 						{ height: SHEET_HEIGHT, paddingBottom: insets.bottom + 16 },
 					]}
 				>
 					<View className="items-center py-2.5">
-						<View className="w-9 h-1 rounded-sm bg-gray-300" />
+						<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
 					</View>
 
 					<ScrollView
@@ -208,7 +210,7 @@ export function HighlightEditSheet({
 						showsVerticalScrollIndicator={false}
 					>
 						<Text
-							className="mb-4 text-[15px] leading-[22px] text-foreground"
+							className="mb-4 text-[15px] leading-[22px] text-foreground dark:text-white"
 							numberOfLines={4}
 						>
 							{highlight?.exact_text ?? ""}
@@ -223,7 +225,7 @@ export function HighlightEditSheet({
 									style={{ backgroundColor: HIGHLIGHT_COLOR_STYLE[color].bar }}
 									className={`h-9 w-9 rounded-full ${
 										highlight?.color === color
-											? "border-2 border-foreground"
+											? "border-2 border-foreground dark:border-white"
 											: ""
 									}`}
 								/>
@@ -235,15 +237,16 @@ export function HighlightEditSheet({
 							onChangeText={setNote}
 							onBlur={flushNote}
 							placeholder="메모 남기기"
+							placeholderTextColor={isDark ? "#666" : "#999"}
 							multiline
 							textAlignVertical="top"
-							className="mb-4 min-h-20 rounded-lg bg-input p-3 text-[15px] text-foreground"
+							className="mb-4 min-h-20 rounded-lg bg-input dark:bg-neutral-800 p-3 text-[15px] text-foreground dark:text-white"
 						/>
 
 						<TouchableOpacity
 							onPress={handleDeletePress}
 							activeOpacity={0.7}
-							className="flex-row items-center justify-center gap-2 rounded-[10px] border border-red-100 bg-red-50 py-2.5"
+							className="flex-row items-center justify-center gap-2 rounded-[10px] border border-red-100 dark:border-red-900/50 bg-red-50 dark:bg-red-950/40 py-2.5"
 						>
 							<Trash2 size={16} color="#ef4444" />
 							<Text className="text-sm font-semibold text-destructive">

--- a/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogBottomSheet.tsx
@@ -11,6 +11,7 @@ import {
 	ScrollView,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import Animated, {
@@ -51,13 +52,13 @@ function SheetBlogItem({
 			onPress={() => onPress(blog.url)}
 			activeOpacity={0.7}
 		>
-			<View className="w-14 h-14 rounded-[14px] bg-input justify-center items-center overflow-hidden">
+			<View className="w-14 h-14 rounded-[14px] bg-input dark:bg-neutral-800 justify-center items-center overflow-hidden">
 				{!logoUri || imgError ? (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{blog.name.charAt(0)}
 						</Text>
 					</View>
@@ -71,7 +72,7 @@ function SheetBlogItem({
 				)}
 			</View>
 			<Text
-				className="text-[11px] text-secondary-foreground text-center leading-[14px]"
+				className="text-[11px] text-secondary-foreground dark:text-neutral-400 text-center leading-[14px]"
 				numberOfLines={1}
 			>
 				{blog.name}
@@ -134,7 +135,7 @@ function FavoriteGridItem({
 			onLongPress={() => onLongPress(item.url, item.title || domain)}
 			activeOpacity={0.7}
 		>
-			<View className="w-14 h-14 rounded-[14px] bg-input justify-center items-center overflow-hidden">
+			<View className="w-14 h-14 rounded-[14px] bg-input dark:bg-neutral-800 justify-center items-center overflow-hidden">
 				{item.favIconUrl && !imgError ? (
 					<Image
 						source={{ uri: item.favIconUrl }}
@@ -144,17 +145,17 @@ function FavoriteGridItem({
 					/>
 				) : (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{(domain || "?").charAt(0).toUpperCase()}
 						</Text>
 					</View>
 				)}
 			</View>
 			<Text
-				className="text-[11px] text-secondary-foreground text-center leading-[14px]"
+				className="text-[11px] text-secondary-foreground dark:text-neutral-400 text-center leading-[14px]"
 				numberOfLines={1}
 			>
 				{domain || item.title}
@@ -193,7 +194,9 @@ function FavoritesSection({ onPress }: { onPress: (url: string) => void }) {
 		<>
 			<View className="flex-row items-center gap-1.5 px-2 mb-3">
 				<Bookmark size={14} color="#f59e0b" fill="#f59e0b" />
-				<Text className="text-sm font-semibold text-gray-500">즐겨찾기</Text>
+				<Text className="text-sm font-semibold text-gray-500 dark:text-neutral-400">
+					즐겨찾기
+				</Text>
 			</View>
 			<View className="mb-6">
 				{rows.map((row, rowIndex) => (
@@ -230,6 +233,7 @@ export function TechBlogBottomSheet({
 	onSelectBlog: (url: string) => void;
 }) {
 	const insets = useSafeAreaInsets();
+	const isDark = useColorScheme() === "dark";
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
@@ -266,20 +270,22 @@ export function TechBlogBottomSheet({
 				</Animated.View>
 
 				<Animated.View
-					className="bg-white rounded-t-[20px]"
+					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
 					style={[
 						sheetStyle,
 						{ height: SHEET_HEIGHT, paddingBottom: insets.bottom + 16 },
 					]}
 				>
 					<View className="items-center py-2.5">
-						<View className="w-9 h-1 rounded-sm bg-gray-300" />
+						<View className="w-9 h-1 rounded-sm bg-gray-300 dark:bg-neutral-700" />
 					</View>
 
 					<View className="flex-row justify-between items-center px-5 pb-4">
-						<Text className="text-lg font-bold text-foreground">바로가기</Text>
+						<Text className="text-lg font-bold text-foreground dark:text-white">
+							바로가기
+						</Text>
 						<TouchableOpacity onPress={onClose} activeOpacity={0.7}>
-							<X size={22} color="#666" />
+							<X size={22} color={isDark ? "#a3a3a3" : "#666"} />
 						</TouchableOpacity>
 					</View>
 
@@ -289,23 +295,23 @@ export function TechBlogBottomSheet({
 					>
 						<FavoritesSection onPress={onSelectBlog} />
 
-						<Text className="text-sm font-semibold text-gray-500 px-2 mb-3">
+						<Text className="text-sm font-semibold text-gray-500 dark:text-neutral-400 px-2 mb-3">
 							블로그 모음
 						</Text>
 						<BlogGrid blogs={BLOG_AGGREGATORS} onPress={onSelectBlog} />
 
-						<Text className="text-sm font-semibold text-gray-500 px-2 mb-3 mt-6">
+						<Text className="text-sm font-semibold text-gray-500 dark:text-neutral-400 px-2 mb-3 mt-6">
 							테크 블로그
 						</Text>
 						<BlogGrid blogs={TECH_BLOGS} onPress={onSelectBlog} />
 
 						<TouchableOpacity
-							className="flex-row items-center justify-center gap-1.5 mt-6 py-3 mx-2 rounded-xl bg-input"
+							className="flex-row items-center justify-center gap-1.5 mt-6 py-3 mx-2 rounded-xl bg-input dark:bg-neutral-800"
 							onPress={() => Linking.openURL(APP_URL.kakaoTalk)}
 							activeOpacity={0.7}
 						>
-							<MessageCircle size={16} color="#666" />
-							<Text className="text-sm text-gray-500 font-medium">
+							<MessageCircle size={16} color={isDark ? "#a3a3a3" : "#666"} />
+							<Text className="text-sm text-gray-500 dark:text-neutral-300 font-medium">
 								블로그 추가 문의하기
 							</Text>
 						</TouchableOpacity>

--- a/apps/app/app/(main)/browser/_components/TechBlogLinks.tsx
+++ b/apps/app/app/(main)/browser/_components/TechBlogLinks.tsx
@@ -7,6 +7,7 @@ import {
 	Linking,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import {
@@ -38,13 +39,13 @@ function BlogItem({
 			onPress={() => onPress(blog.url)}
 			activeOpacity={0.7}
 		>
-			<View className="w-14 h-14 rounded-[14px] bg-input justify-center items-center overflow-hidden">
+			<View className="w-14 h-14 rounded-[14px] bg-input dark:bg-neutral-800 justify-center items-center overflow-hidden">
 				{!logoUri || imgError ? (
 					<View
-						className="justify-center items-center bg-[#e0e0e0]"
+						className="justify-center items-center bg-[#e0e0e0] dark:bg-neutral-700"
 						style={{ width: 36, height: 36, borderRadius: 4 }}
 					>
-						<Text className="text-base font-bold text-gray-500">
+						<Text className="text-base font-bold text-gray-500 dark:text-neutral-300">
 							{blog.name.charAt(0)}
 						</Text>
 					</View>
@@ -58,7 +59,7 @@ function BlogItem({
 				)}
 			</View>
 			<Text
-				className="text-[11px] text-secondary-foreground text-center leading-[14px]"
+				className="text-[11px] text-secondary-foreground dark:text-neutral-400 text-center leading-[14px]"
 				numberOfLines={1}
 			>
 				{blog.name}
@@ -73,6 +74,7 @@ export function TechBlogLinks({
 	onSelectBlog: (url: string) => void;
 }) {
 	const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
+	const isDark = useColorScheme() === "dark";
 
 	const renderItem = useCallback(
 		({ item }: { item: TechBlog }) => (
@@ -84,14 +86,18 @@ export function TechBlogLinks({
 	return (
 		<View className="mt-8">
 			<View className="flex-row justify-between items-center mb-4 px-5">
-				<Text className="text-base font-bold text-foreground">블로그 모음</Text>
+				<Text className="text-base font-bold text-foreground dark:text-white">
+					블로그 모음
+				</Text>
 				<TouchableOpacity
 					className="flex-row items-center gap-0.5"
 					onPress={() => setIsBottomSheetVisible(true)}
 					activeOpacity={0.7}
 				>
-					<Text className="text-[13px] text-muted-foreground">전체보기</Text>
-					<ChevronRight size={14} color="#999" />
+					<Text className="text-[13px] text-muted-foreground dark:text-neutral-500">
+						전체보기
+					</Text>
+					<ChevronRight size={14} color={isDark ? "#737373" : "#999"} />
 				</TouchableOpacity>
 			</View>
 
@@ -105,7 +111,9 @@ export function TechBlogLinks({
 			/>
 
 			<View className="mt-7 mb-4 px-5">
-				<Text className="text-base font-bold text-foreground">테크 블로그</Text>
+				<Text className="text-base font-bold text-foreground dark:text-white">
+					테크 블로그
+				</Text>
 			</View>
 
 			<FlatList
@@ -118,12 +126,12 @@ export function TechBlogLinks({
 			/>
 
 			<TouchableOpacity
-				className="flex-row items-center justify-center gap-1.5 mt-8 mb-4 py-3 mx-5 rounded-xl bg-input"
+				className="flex-row items-center justify-center gap-1.5 mt-8 mb-4 py-3 mx-5 rounded-xl bg-input dark:bg-neutral-800"
 				onPress={() => Linking.openURL(URL.kakaoTalk)}
 				activeOpacity={0.7}
 			>
-				<MessageCircle size={16} color="#666" />
-				<Text className="text-sm text-gray-500 font-medium">
+				<MessageCircle size={16} color={isDark ? "#a3a3a3" : "#666"} />
+				<Text className="text-sm text-gray-500 dark:text-neutral-300 font-medium">
 					블로그 추가 문의하기
 				</Text>
 			</TouchableOpacity>

--- a/apps/app/app/(main)/index.tsx
+++ b/apps/app/app/(main)/index.tsx
@@ -14,6 +14,7 @@ import {
 	FlatList,
 	Text,
 	TouchableOpacity,
+	useColorScheme,
 	View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -27,9 +28,19 @@ import { useMemoList } from "./_hooks/useMemoList";
 
 const READ_DONE_PROGRESS = 0.98;
 
+/** 선택된 필터 칩의 배경 클래스 */
+const SELECTED_FILTER_CLASS = "bg-foreground dark:bg-neutral-700";
+/** 선택되지 않은 필터 칩의 배경 클래스 */
+const UNSELECTED_FILTER_CLASS = "bg-muted dark:bg-neutral-800";
+/** 선택된 필터 칩의 글자 클래스 */
+const SELECTED_FILTER_TEXT_CLASS = "text-white";
+/** 선택되지 않은 필터 칩의 글자 클래스 */
+const UNSELECTED_FILTER_TEXT_CLASS = "text-gray-500 dark:text-neutral-400";
+
 export default function MemoScreen() {
 	const insets = useSafeAreaInsets();
 	const router = useRouter();
+	const isDark = useColorScheme() === "dark";
 	const { filter: filterParam } = useLocalSearchParams<{ filter?: string }>();
 	const [selectedMemo, setSelectedMemo] = useState<MemoItem | null>(null);
 	const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -73,6 +84,9 @@ export default function MemoScreen() {
 		return position.progress;
 	};
 
+	const unselectedFilterIconColor = isDark ? "#a3a3a3" : "#666";
+	const emptyStateIconColor = isDark ? "#404040" : "#ddd";
+
 	const navigateToBrowser = useCallback(
 		(url: string) => {
 			router.navigate({
@@ -84,16 +98,19 @@ export default function MemoScreen() {
 	);
 
 	return (
-		<View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+		<View
+			className="flex-1 bg-background dark:bg-neutral-950"
+			style={{ paddingTop: insets.top }}
+		>
 			<View className="flex-1">
 				<View className="flex-row justify-between items-center px-5 pt-4 pb-1">
-					<Text className="text-[22px] font-extrabold text-foreground tracking-tight">
+					<Text className="text-[22px] font-extrabold text-foreground dark:text-white tracking-tight">
 						웹 메모
 					</Text>
 					<View className="flex-row items-center gap-2">
 						{!isLoggedIn ? (
 							<TouchableOpacity
-								className="flex-row items-center gap-1.5 px-3 py-1.5 rounded-full bg-foreground"
+								className="flex-row items-center gap-1.5 px-3 py-1.5 rounded-full bg-foreground dark:bg-neutral-700"
 								onPress={() => router.navigate("/(auth)/login")}
 							>
 								<LogIn size={14} color="#fff" />
@@ -101,7 +118,7 @@ export default function MemoScreen() {
 							</TouchableOpacity>
 						) : null}
 						<TouchableOpacity
-							className="flex-row items-center gap-1 px-3 py-1.5 rounded-full bg-foreground"
+							className="flex-row items-center gap-1 px-3 py-1.5 rounded-full bg-foreground dark:bg-neutral-700"
 							onPress={() => setIsAddModalOpen(true)}
 							activeOpacity={0.8}
 						>
@@ -113,18 +130,18 @@ export default function MemoScreen() {
 					</View>
 				</View>
 
-				<Text className="text-sm text-gray-400 px-5 mb-4">
+				<Text className="text-sm text-gray-400 dark:text-neutral-500 px-5 mb-4">
 					웹서핑하며 간편하게 메모하세요
 				</Text>
 
 				{!isLoggedIn ? (
 					<TouchableOpacity
-						className="flex-row items-center gap-2 mx-5 mb-3 px-3.5 py-2.5 bg-card rounded-xl border border-border"
+						className="flex-row items-center gap-2 mx-5 mb-3 px-3.5 py-2.5 bg-card dark:bg-neutral-900 rounded-xl border border-border dark:border-neutral-800"
 						onPress={() => router.navigate("/(auth)/login")}
 						activeOpacity={0.7}
 					>
 						<LogIn size={14} color="#7c3aed" />
-						<Text className="flex-1 text-[13px] text-secondary-foreground">
+						<Text className="flex-1 text-[13px] text-secondary-foreground dark:text-neutral-300">
 							로그인하면 메모가 동기화됩니다
 						</Text>
 						<Text className="text-xs text-accent font-semibold">로그인</Text>
@@ -133,55 +150,55 @@ export default function MemoScreen() {
 
 				<View className="flex-row px-5 mb-4 gap-2">
 					<TouchableOpacity
-						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "all" ? "bg-foreground" : "bg-muted"}`}
+						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "all" ? SELECTED_FILTER_CLASS : UNSELECTED_FILTER_CLASS}`}
 						onPress={() => setFilter("all")}
 					>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "all" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "all" ? SELECTED_FILTER_TEXT_CLASS : UNSELECTED_FILTER_TEXT_CLASS}`}
 						>
 							전체
 						</Text>
 					</TouchableOpacity>
 					<TouchableOpacity
-						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "wish" ? "bg-foreground" : "bg-muted"}`}
+						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "wish" ? SELECTED_FILTER_CLASS : UNSELECTED_FILTER_CLASS}`}
 						onPress={() => setFilter("wish")}
 					>
 						<Heart
 							size={12}
-							fill={filter === "wish" ? "#fff" : "#666"}
-							color={filter === "wish" ? "#fff" : "#666"}
+							fill={filter === "wish" ? "#fff" : unselectedFilterIconColor}
+							color={filter === "wish" ? "#fff" : unselectedFilterIconColor}
 						/>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "wish" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "wish" ? SELECTED_FILTER_TEXT_CLASS : UNSELECTED_FILTER_TEXT_CLASS}`}
 						>
 							위시리스트
 						</Text>
 					</TouchableOpacity>
 					<TouchableOpacity
-						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "star" ? "bg-foreground" : "bg-muted"}`}
+						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "star" ? SELECTED_FILTER_CLASS : UNSELECTED_FILTER_CLASS}`}
 						onPress={() => setFilter("star")}
 					>
 						<Star
 							size={12}
-							fill={filter === "star" ? "#fff" : "#666"}
-							color={filter === "star" ? "#fff" : "#666"}
+							fill={filter === "star" ? "#fff" : unselectedFilterIconColor}
+							color={filter === "star" ? "#fff" : unselectedFilterIconColor}
 						/>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "star" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "star" ? SELECTED_FILTER_TEXT_CLASS : UNSELECTED_FILTER_TEXT_CLASS}`}
 						>
 							중요
 						</Text>
 					</TouchableOpacity>
 					<TouchableOpacity
-						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "reading" ? "bg-foreground" : "bg-muted"}`}
+						className={`flex-row items-center gap-1 px-3.5 py-[7px] rounded-[20px] ${filter === "reading" ? SELECTED_FILTER_CLASS : UNSELECTED_FILTER_CLASS}`}
 						onPress={() => setFilter("reading")}
 					>
 						<BookOpen
 							size={12}
-							color={filter === "reading" ? "#fff" : "#666"}
+							color={filter === "reading" ? "#fff" : unselectedFilterIconColor}
 						/>
 						<Text
-							className={`text-[13px] font-semibold ${filter === "reading" ? "text-white" : "text-gray-500"}`}
+							className={`text-[13px] font-semibold ${filter === "reading" ? SELECTED_FILTER_TEXT_CLASS : UNSELECTED_FILTER_TEXT_CLASS}`}
 						>
 							읽는 중
 						</Text>
@@ -192,7 +209,7 @@ export default function MemoScreen() {
 					<ActivityIndicator style={{ marginTop: 40 }} size="large" />
 				) : memos.length > 0 ? (
 					<View className="flex-1 px-5">
-						<Text className="text-[17px] font-bold text-foreground mb-3">
+						<Text className="text-[17px] font-bold text-foreground dark:text-white mb-3">
 							{filter === "wish"
 								? "위시리스트"
 								: filter === "star"
@@ -233,15 +250,15 @@ export default function MemoScreen() {
 				) : (
 					<View className="items-center pt-[60px] gap-3">
 						{filter === "wish" ? (
-							<Heart size={48} color="#ddd" />
+							<Heart size={48} color={emptyStateIconColor} />
 						) : filter === "star" ? (
-							<Star size={48} color="#ddd" />
+							<Star size={48} color={emptyStateIconColor} />
 						) : filter === "reading" ? (
-							<BookOpen size={48} color="#ddd" />
+							<BookOpen size={48} color={emptyStateIconColor} />
 						) : (
-							<Globe size={48} color="#ddd" />
+							<Globe size={48} color={emptyStateIconColor} />
 						)}
-						<Text className="text-base font-semibold text-muted-foreground">
+						<Text className="text-base font-semibold text-muted-foreground dark:text-neutral-400">
 							{filter === "wish"
 								? "위시리스트가 비어있습니다"
 								: filter === "star"
@@ -250,7 +267,7 @@ export default function MemoScreen() {
 										? "읽는 중인 메모가 없습니다"
 										: "저장된 메모가 없습니다"}
 						</Text>
-						<Text className="text-[13px] text-gray-300">
+						<Text className="text-[13px] text-gray-300 dark:text-neutral-600">
 							{filter === "wish"
 								? "브라우저에서 마음에 드는 페이지를 저장해보세요"
 								: filter === "star"
@@ -260,7 +277,7 @@ export default function MemoScreen() {
 										: "브라우저에서 웹서핑하며 메모를 남겨보세요"}
 						</Text>
 						<TouchableOpacity
-							className="mt-2 bg-foreground px-5 py-3 rounded-3xl"
+							className="mt-2 bg-foreground dark:bg-neutral-700 px-5 py-3 rounded-3xl"
 							onPress={() => router.navigate("/(main)/browser")}
 						>
 							<Text className="text-sm font-semibold text-white">

--- a/apps/app/app/(main)/settings/index.tsx
+++ b/apps/app/app/(main)/settings/index.tsx
@@ -5,6 +5,9 @@ import {
 	LogIn,
 	LogOut,
 	MessageCircle,
+	Moon,
+	Smartphone,
+	Sun,
 	User,
 } from "lucide-react-native";
 import {
@@ -17,10 +20,23 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuth } from "@/lib/auth/AuthProvider";
+import { useTheme } from "@/lib/context/ThemeContext";
 import {
 	useSettingQuery,
 	useSettingUpsertMutation,
 } from "@/lib/hooks/useSetting";
+import type { TThemePreference } from "@/lib/storage/themePreference";
+
+/** 설정 화면에 노출할 테마 선택 항목 */
+const THEME_OPTIONS: {
+	value: TThemePreference;
+	label: string;
+	Icon: typeof Sun;
+}[] = [
+	{ value: "system", label: "시스템", Icon: Smartphone },
+	{ value: "light", label: "라이트", Icon: Sun },
+	{ value: "dark", label: "다크", Icon: Moon },
+];
 
 export default function SettingsScreen() {
 	const insets = useSafeAreaInsets();
@@ -28,6 +44,7 @@ export default function SettingsScreen() {
 	const { session, signOut, isLoggedIn } = useAuth();
 	const { showImpression, showActionItem } = useSettingQuery(isLoggedIn);
 	const { mutate: upsertSetting } = useSettingUpsertMutation();
+	const { themePreference, isDark, setThemePreference } = useTheme();
 
 	const handleSignOut = () => {
 		Alert.alert("로그아웃", "로그아웃 하시겠습니까?", [
@@ -43,9 +60,12 @@ export default function SettingsScreen() {
 	const appVersion = Constants.expoConfig?.version;
 
 	return (
-		<View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
+		<View
+			className="flex-1 bg-white dark:bg-neutral-950"
+			style={{ paddingTop: insets.top }}
+		>
 			<View className="px-5 pt-4 pb-4">
-				<Text className="text-[22px] font-extrabold text-foreground tracking-tight">
+				<Text className="text-[22px] font-extrabold text-foreground dark:text-white tracking-tight">
 					설정
 				</Text>
 			</View>
@@ -53,27 +73,27 @@ export default function SettingsScreen() {
 			<View className="flex-1 px-5">
 				{/* Account Section */}
 				<View className="mb-7">
-					<Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2.5">
+					<Text className="text-sm font-semibold text-muted-foreground dark:text-neutral-500 uppercase tracking-wide mb-2.5">
 						계정
 					</Text>
-					<View className="bg-card rounded-[14px] p-4 border border-muted">
+					<View className="bg-card dark:bg-neutral-900 rounded-[14px] p-4 border border-muted dark:border-neutral-800">
 						{isLoggedIn && session ? (
 							<>
 								<View className="flex-row items-center gap-3 mb-4">
-									<View className="w-10 h-10 rounded-full bg-foreground justify-center items-center">
+									<View className="w-10 h-10 rounded-full bg-foreground dark:bg-neutral-700 justify-center items-center">
 										<User size={20} color="#fff" />
 									</View>
 									<View className="flex-1">
-										<Text className="text-[15px] font-semibold text-foreground">
+										<Text className="text-[15px] font-semibold text-foreground dark:text-white">
 											{session.user.email}
 										</Text>
-										<Text className="text-[13px] text-muted-foreground mt-0.5">
+										<Text className="text-[13px] text-muted-foreground dark:text-neutral-500 mt-0.5">
 											로그인됨
 										</Text>
 									</View>
 								</View>
 								<TouchableOpacity
-									className="flex-row items-center justify-center gap-2 py-2.5 rounded-[10px] border border-red-100 bg-red-50"
+									className="flex-row items-center justify-center gap-2 py-2.5 rounded-[10px] border border-red-100 dark:border-red-900/50 bg-red-50 dark:bg-red-950/40"
 									onPress={handleSignOut}
 								>
 									<LogOut size={16} color="#ef4444" />
@@ -84,7 +104,7 @@ export default function SettingsScreen() {
 							</>
 						) : (
 							<TouchableOpacity
-								className="flex-row items-center justify-center gap-2 py-3 rounded-[10px] bg-foreground"
+								className="flex-row items-center justify-center gap-2 py-3 rounded-[10px] bg-foreground dark:bg-neutral-700"
 								onPress={handleLogin}
 							>
 								<LogIn size={18} color="#fff" />
@@ -96,19 +116,65 @@ export default function SettingsScreen() {
 					</View>
 				</View>
 
+				{/* Theme Section */}
+				<View className="mb-7">
+					<Text className="text-sm font-semibold text-muted-foreground dark:text-neutral-500 uppercase tracking-wide mb-2.5">
+						화면 테마
+					</Text>
+					<View className="bg-card dark:bg-neutral-900 rounded-[14px] p-4 border border-muted dark:border-neutral-800">
+						<View className="flex-row gap-2">
+							{THEME_OPTIONS.map(({ value, label, Icon }) => {
+								const isSelected = themePreference === value;
+
+								return (
+									<TouchableOpacity
+										key={value}
+										className={`flex-1 items-center gap-1.5 py-3 rounded-[10px] border ${
+											isSelected
+												? "bg-foreground dark:bg-neutral-700 border-transparent"
+												: "bg-muted dark:bg-neutral-800 border-transparent"
+										}`}
+										onPress={() => setThemePreference(value)}
+										activeOpacity={0.7}
+									>
+										<Icon
+											size={18}
+											color={
+												isSelected ? "#fff" : isDark ? "#a3a3a3" : "#555555"
+											}
+										/>
+										<Text
+											className={`text-[13px] font-semibold ${
+												isSelected
+													? "text-white"
+													: "text-secondary-foreground dark:text-neutral-400"
+											}`}
+										>
+											{label}
+										</Text>
+									</TouchableOpacity>
+								);
+							})}
+						</View>
+						<Text className="text-[13px] text-muted-foreground dark:text-neutral-500 mt-3">
+							시스템을 고르면 기기 설정을 따라가요
+						</Text>
+					</View>
+				</View>
+
 				{/* Memo Fields Section */}
 				{isLoggedIn && (
 					<View className="mb-7">
-						<Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2.5">
+						<Text className="text-sm font-semibold text-muted-foreground dark:text-neutral-500 uppercase tracking-wide mb-2.5">
 							메모 입력 항목
 						</Text>
-						<View className="bg-card rounded-[14px] p-4 border border-muted gap-3">
+						<View className="bg-card dark:bg-neutral-900 rounded-[14px] p-4 border border-muted dark:border-neutral-800 gap-3">
 							<View className="flex-row justify-between items-center py-1">
 								<View className="flex-1 mr-3">
-									<Text className="text-[15px] text-secondary-foreground">
+									<Text className="text-[15px] text-secondary-foreground dark:text-neutral-300">
 										느낀 점 입력란 표시
 									</Text>
-									<Text className="text-[13px] text-muted-foreground mt-0.5">
+									<Text className="text-[13px] text-muted-foreground dark:text-neutral-500 mt-0.5">
 										이미 작성한 내용은 계속 보여요
 									</Text>
 								</View>
@@ -121,10 +187,10 @@ export default function SettingsScreen() {
 							</View>
 							<View className="flex-row justify-between items-center py-1">
 								<View className="flex-1 mr-3">
-									<Text className="text-[15px] text-secondary-foreground">
+									<Text className="text-[15px] text-secondary-foreground dark:text-neutral-300">
 										액션 아이템 입력란 표시
 									</Text>
-									<Text className="text-[13px] text-muted-foreground mt-0.5">
+									<Text className="text-[13px] text-muted-foreground dark:text-neutral-500 mt-0.5">
 										이미 작성한 내용은 계속 보여요
 									</Text>
 								</View>
@@ -141,23 +207,23 @@ export default function SettingsScreen() {
 
 				{/* App Info Section */}
 				<View className="mb-7">
-					<Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2.5">
+					<Text className="text-sm font-semibold text-muted-foreground dark:text-neutral-500 uppercase tracking-wide mb-2.5">
 						앱 정보
 					</Text>
-					<View className="bg-card rounded-[14px] p-4 border border-muted">
+					<View className="bg-card dark:bg-neutral-900 rounded-[14px] p-4 border border-muted dark:border-neutral-800">
 						<View className="flex-row justify-between items-center py-2">
-							<Text className="text-[15px] text-secondary-foreground">
+							<Text className="text-[15px] text-secondary-foreground dark:text-neutral-300">
 								앱 이름
 							</Text>
-							<Text className="text-[15px] text-foreground font-medium">
+							<Text className="text-[15px] text-foreground dark:text-white font-medium">
 								웹 메모
 							</Text>
 						</View>
 						<View className="flex-row justify-between items-center py-2">
-							<Text className="text-[15px] text-secondary-foreground">
+							<Text className="text-[15px] text-secondary-foreground dark:text-neutral-300">
 								버전
 							</Text>
-							<Text className="text-[15px] text-foreground font-medium">
+							<Text className="text-[15px] text-foreground dark:text-white font-medium">
 								{appVersion}
 							</Text>
 						</View>
@@ -166,10 +232,10 @@ export default function SettingsScreen() {
 
 				{/* Support Section */}
 				<View className="mb-7">
-					<Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2.5">
+					<Text className="text-sm font-semibold text-muted-foreground dark:text-neutral-500 uppercase tracking-wide mb-2.5">
 						지원
 					</Text>
-					<View className="bg-card rounded-[14px] p-4 border border-muted">
+					<View className="bg-card dark:bg-neutral-900 rounded-[14px] p-4 border border-muted dark:border-neutral-800">
 						<TouchableOpacity
 							className="flex-row justify-between items-center py-2"
 							onPress={() =>
@@ -178,13 +244,13 @@ export default function SettingsScreen() {
 							activeOpacity={0.6}
 						>
 							<View className="flex-row items-center gap-2">
-								<MessageCircle size={16} color="#555" />
-								<Text className="text-[15px] text-secondary-foreground">
+								<MessageCircle size={16} color={isDark ? "#a3a3a3" : "#555"} />
+								<Text className="text-[15px] text-secondary-foreground dark:text-neutral-300">
 									문의하기
 								</Text>
 							</View>
 							<View className="flex-row items-center gap-2">
-								<ChevronRight size={14} color="#999" />
+								<ChevronRight size={14} color={isDark ? "#737373" : "#999"} />
 							</View>
 						</TouchableOpacity>
 					</View>

--- a/apps/app/app/_layout.tsx
+++ b/apps/app/app/_layout.tsx
@@ -9,6 +9,7 @@ import { Text, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AuthProvider, useAuth } from "@/lib/auth/AuthProvider";
+import { ThemeProvider, useTheme } from "@/lib/context/ThemeContext";
 import { handleSharedUrl } from "@/lib/sharing/shareHandler";
 import { syncMemosToSupabase } from "@/lib/storage/syncService";
 import "../global.css";
@@ -105,6 +106,25 @@ function ShareIntentHandler() {
 	);
 }
 
+/** 화면 전환 중 테마와 어긋나는 배경이 비치지 않도록 스택 배경색을 테마에 맞춘다 */
+function ThemedStack() {
+	const { isDark } = useTheme();
+
+	return (
+		<Stack
+			screenOptions={{
+				headerShown: false,
+				contentStyle: { backgroundColor: isDark ? "#171717" : "#ffffff" },
+			}}
+		>
+			<Stack.Screen name="index" />
+			<Stack.Screen name="(auth)" />
+			<Stack.Screen name="(main)" />
+			<Stack.Screen name="+not-found" />
+		</Stack>
+	);
+}
+
 export default function RootLayout() {
 	useEffect(() => {
 		SplashScreen.hideAsync();
@@ -112,19 +132,16 @@ export default function RootLayout() {
 
 	return (
 		<QueryClientProvider client={queryClient}>
-			<AuthProvider>
-				<GestureHandlerRootView>
-					<Stack screenOptions={{ headerShown: false }}>
-						<Stack.Screen name="index" />
-						<Stack.Screen name="(auth)" />
-						<Stack.Screen name="(main)" />
-						<Stack.Screen name="+not-found" />
-					</Stack>
-				</GestureHandlerRootView>
-				<SyncOnAuth />
-				<ShareIntentHandler />
-				<StatusBar style="dark" />
-			</AuthProvider>
+			<ThemeProvider>
+				<AuthProvider>
+					<GestureHandlerRootView>
+						<ThemedStack />
+					</GestureHandlerRootView>
+					<SyncOnAuth />
+					<ShareIntentHandler />
+					<StatusBar style="auto" />
+				</AuthProvider>
+			</ThemeProvider>
 		</QueryClientProvider>
 	);
 }

--- a/apps/app/lib/context/ThemeContext.tsx
+++ b/apps/app/lib/context/ThemeContext.tsx
@@ -1,0 +1,75 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
+import { Appearance, useColorScheme } from "react-native";
+import {
+	getThemePreference,
+	saveThemePreference,
+	type TThemePreference,
+} from "@/lib/storage/themePreference";
+
+interface IFThemeContextValue {
+	/** 사용자가 설정 화면에서 고른 테마 */
+	themePreference: TThemePreference;
+	/** 실제로 적용 중인 색상 스킴이 다크인지 여부 */
+	isDark: boolean;
+	/** 테마를 즉시 적용하고 기기에 저장한다 */
+	setThemePreference: (preference: TThemePreference) => void;
+}
+
+const ThemeContext = createContext<IFThemeContextValue | null>(null);
+
+/**
+ * 저장된 테마 설정을 Appearance에 적용한다.
+ * @description NativeWind v4의 `dark:` 클래스와 react-native의 useColorScheme이
+ * 모두 Appearance를 따르므로, setColorScheme만 호출하면 앱 전체 테마가 바뀐다.
+ * system은 null을 넘겨 기기 설정 추종으로 되돌린다.
+ */
+function applyColorScheme(preference: TThemePreference) {
+	Appearance.setColorScheme(preference === "system" ? null : preference);
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+	const [themePreference, setThemePreferenceState] =
+		useState<TThemePreference>("system");
+	const colorScheme = useColorScheme();
+
+	useEffect(() => {
+		getThemePreference().then((preference) => {
+			setThemePreferenceState(preference);
+			applyColorScheme(preference);
+		});
+	}, []);
+
+	const setThemePreference = useCallback((preference: TThemePreference) => {
+		setThemePreferenceState(preference);
+		applyColorScheme(preference);
+		saveThemePreference(preference);
+	}, []);
+
+	return (
+		<ThemeContext.Provider
+			value={{
+				themePreference,
+				isDark: colorScheme === "dark",
+				setThemePreference,
+			}}
+		>
+			{children}
+		</ThemeContext.Provider>
+	);
+}
+
+/** 현재 테마 설정과 변경 함수를 반환한다 */
+export function useTheme() {
+	const context = useContext(ThemeContext);
+	if (!context) {
+		throw new Error("useTheme must be used within ThemeProvider");
+	}
+
+	return context;
+}

--- a/apps/app/lib/storage/themePreference.ts
+++ b/apps/app/lib/storage/themePreference.ts
@@ -1,0 +1,31 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const THEME_PREFERENCE_KEY = "webmemo:theme-preference";
+
+/** 사용자가 고른 화면 테마. system은 기기 설정을 그대로 따른다 */
+export type TThemePreference = "system" | "light" | "dark";
+
+const THEME_PREFERENCES: TThemePreference[] = ["system", "light", "dark"];
+
+/** 저장된 테마 설정을 반환한다. 값이 없거나 알 수 없는 값이면 system으로 본다 */
+export async function getThemePreference(): Promise<TThemePreference> {
+	try {
+		const value = await AsyncStorage.getItem(THEME_PREFERENCE_KEY);
+		if (value && THEME_PREFERENCES.includes(value as TThemePreference)) {
+			return value as TThemePreference;
+		}
+
+		return "system";
+	} catch {
+		return "system";
+	}
+}
+
+/** 테마 설정을 기기에 저장한다 */
+export async function saveThemePreference(
+	preference: TThemePreference,
+): Promise<void> {
+	try {
+		await AsyncStorage.setItem(THEME_PREFERENCE_KEY, preference);
+	} catch {}
+}


### PR DESCRIPTION
## 요약

- 앱 설정 화면에 **시스템 / 라이트 / 다크** 3단 테마 선택을 추가했습니다. 기존에는 `app.json`의 `userInterfaceStyle: "automatic"`으로 기기 설정만 따라갈 수 있어 앱에서 테마를 바꿀 방법이 없었습니다.
- 고른 값은 AsyncStorage에 저장돼 앱을 다시 켜도 유지됩니다. 로그인 여부와 무관하게 동작합니다.
- 테마를 다크로 고를 수 있게 되면서 드러나는, `dark:` 대응이 빠져 있던 화면들의 색상을 함께 보강했습니다.

## 구현 방식

`Appearance.setColorScheme()`으로 적용합니다. NativeWind v4의 `dark:` 클래스와 `react-native`의 `useColorScheme()`이 모두 Appearance를 따르므로, 이 한 곳만 바꾸면 앱 전체 테마가 전환됩니다. 기존 컴포넌트들의 `useColorScheme` import는 그대로 두었습니다. `system`을 고르면 `null`을 넘겨 기기 설정 추종으로 되돌립니다.

## 변경 파일

**테마 인프라**
- `apps/app/lib/storage/themePreference.ts` (신규) — AsyncStorage 저장·조회, 알 수 없는 값은 `system`으로 처리
- `apps/app/lib/context/ThemeContext.tsx` (신규) — 초기 로드·적용, 변경 시 즉시 반영 및 저장
- `apps/app/app/_layout.tsx` — `ThemeProvider` 적용, `StatusBar`를 `style="auto"`로, 화면 전환 중 테마와 어긋난 배경이 비치지 않도록 스택 배경색 지정
- `apps/app/app/(main)/settings/index.tsx` — 「화면 테마」 섹션 추가

**다크 테마 색상 보강**
- 홈 `app/(main)/index.tsx`, 설정, 로그인 `app/(auth)/login/index.tsx`, 탭바 `CustomTabBar.tsx`
- `HighlightEditSheet.tsx`, `TechBlogBottomSheet.tsx`, `EmptyBrowserView.tsx`, `FavoriteLinks.tsx`, `TechBlogLinks.tsx`, `TodayArticles.tsx`
- 하드코딩된 아이콘·placeholder 색을 테마별로 분기
- `SocialLoginButton.tsx` — 검정 배경이라 다크 화면에 묻히던 Apple 버튼에 테두리 추가

색 체계는 기존 `MemoCard`의 톤을 따랐습니다: 화면 배경 `neutral-950`, 카드·시트 `neutral-900`, 입력·칩 `neutral-800`, 테두리 `neutral-800`.

## 참고

- `tailwind.config.js`의 커스텀 컬러(`foreground`, `card` 등)는 여전히 라이트 값 단일 정의이고, 다크는 `dark:` 유틸리티로 처리하는 기존 방식을 유지했습니다. 컬러 토큰 자체를 다크까지 정의하는 리팩터링은 범위가 커서 이 PR에 넣지 않았습니다.
- `apps/app/components/browser/` 아래 `FavoriteLinks.tsx`는 어디에서도 import되지 않는 미사용 중복 파일이라 손대지 않았습니다.
- **시뮬레이터/기기 렌더 확인은 하지 못했습니다.** `pnpm type-check`와 `pnpm lint`만 통과한 상태이니, 아래 체크리스트로 실제 화면 확인이 필요합니다.

## 테스트 체크리스트

- [ ] 설정 → 화면 테마에서 라이트/다크를 고르면 앱 전체가 즉시 바뀐다
- [ ] 시스템을 고르면 기기 다크모드 설정을 따라간다
- [ ] 앱을 완전히 종료한 뒤 다시 켜도 고른 테마가 유지된다
- [ ] 로그아웃 상태에서도 테마 선택이 동작한다
- [ ] 다크에서 홈·설정·로그인·브라우저 빈 화면, 탭바의 글자가 모두 읽힌다
- [ ] 다크에서 하이라이트 편집 시트·바로가기 시트가 앱 톤과 맞는다
- [ ] 다크에서 Apple 로그인 버튼이 배경과 구분된다
- [ ] 상태바 글자색이 라이트/다크에서 각각 알맞게 보인다
- [ ] 화면 전환 시 다른 톤의 배경이 깜빡이지 않는다