### PR TITLE
Fix: 안드로이드 뒤로가기가 탭 전환 대신 웹뷰 히스토리를 따르도록 수정

### DIFF
--- a/apps/app/app/(main)/browser/_hooks/useAndroidWebViewBack.ts
+++ b/apps/app/app/(main)/browser/_hooks/useAndroidWebViewBack.ts
@@ -1,0 +1,51 @@
+import { useFocusEffect } from "@react-navigation/native";
+import type { RefObject } from "react";
+import { useCallback, useRef } from "react";
+import { BackHandler, Platform } from "react-native";
+import type WebView from "react-native-webview";
+
+/**
+ * Android 하드웨어 뒤로가기를 웹뷰 히스토리에 연결한다.
+ * @description 기본 동작은 탭 네비게이션을 되돌려 브라우저 탭에서 메모 탭으로 빠져나가므로,
+ * 보고 있던 페이지의 히스토리가 통째로 무시된다. 브라우저 탭이 포커스된 동안에는 웹뷰에
+ * 이전 페이지가 남아 있으면 웹뷰를 먼저 뒤로 보내고, 히스토리를 다 쓴 뒤에야 기본 동작
+ * (탭 전환·앱 종료)에 넘긴다. iOS는 스와이프 제스처가 같은 역할을 하므로 등록하지 않는다.
+ */
+export function useAndroidWebViewBack({
+	webViewRef,
+}: {
+	webViewRef: RefObject<WebView | null>;
+}) {
+	const canGoBackRef = useRef(false);
+
+	/** `onNavigationStateChange`가 알려준 웹뷰 히스토리 보유 여부를 반영한다. */
+	const syncCanGoBack = useCallback((canGoBack: boolean) => {
+		canGoBackRef.current = canGoBack;
+	}, []);
+
+	useFocusEffect(
+		useCallback(() => {
+			if (Platform.OS !== "android") {
+				return;
+			}
+
+			const subscription = BackHandler.addEventListener(
+				"hardwareBackPress",
+				() => {
+					// 웹뷰가 언마운트된 홈(빈 브라우저) 화면에서는 직전 페이지의 값이 남아 있을 수 있다.
+					if (!canGoBackRef.current || !webViewRef.current) {
+						return false;
+					}
+
+					webViewRef.current.goBack();
+
+					return true;
+				},
+			);
+
+			return () => subscription.remove();
+		}, [webViewRef]),
+	);
+
+	return { syncCanGoBack };
+}

--- a/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
+++ b/apps/app/app/(main)/browser/_hooks/useBrowserState.ts
@@ -53,6 +53,7 @@ import {
 	INJECTED_JS_ON_NAVIGATION,
 	SCROLL_DETECT_JS,
 } from "../_utils/webViewScripts";
+import { useAndroidWebViewBack } from "./useAndroidWebViewBack";
 
 const SPRING_CONFIG = { damping: 20, stiffness: 150 };
 const MIN_PANEL_RATIO = 0.15;
@@ -154,6 +155,8 @@ export function useBrowserState({
 	const { tabBarTranslateY, headerTranslateY, isBrowserActive } =
 		useBrowserScroll();
 
+	const { syncCanGoBack } = useAndroidWebViewBack({ webViewRef });
+
 	useEffect(() => {
 		getPanelRatio().then((ratio) => {
 			if (ratio !== null) setSavedRatio(ratio);
@@ -182,6 +185,7 @@ export function useBrowserState({
 	}, [paramUrl, navTs, panelHeight]);
 
 	const handleNavigationStateChange = (navState: WebViewNavigation) => {
+		syncCanGoBack(navState.canGoBack);
 		setCurrentUrl(navState.url);
 		setPageTitle(navState.title ?? "");
 		setPageFavIconUrl(undefined);


### PR DESCRIPTION
## 설명

Android에서 하드웨어 뒤로가기를 누르면 보고 있던 페이지의 히스토리를 건너뛰고 탭이 바뀌는 문제를 수정했습니다.

**원인**

`apps/app` 전체에 `BackHandler` 등록이 전혀 없어, Android 하드웨어 뒤로가기가 react-navigation 기본 동작으로만 처리되고 있었습니다. 바텀 탭의 기본 `backBehavior`는 첫 번째 탭으로 되돌아가는 동작이라, 브라우저 탭에서 뒤로가기를 누르면 웹뷰 히스토리와 무관하게 곧바로 메모 탭으로 빠져나갔습니다. iOS는 `allowsBackForwardNavigationGestures`(스와이프 뒤로가기)가 있어 이 문제가 드러나지 않았습니다.

**해결**

브라우저 탭이 포커스된 동안에만 `hardwareBackPress`를 가로채는 `useAndroidWebViewBack` 훅을 추가했습니다.

- 웹뷰에 이전 페이지가 있으면 → `webViewRef.goBack()` 후 `true` 반환(기본 동작 차단)
- 히스토리를 모두 소진했거나 홈(빈 브라우저) 화면이라 웹뷰가 언마운트된 상태면 → `false` 반환해 기존 기본 동작(탭 전환·앱 종료)을 그대로 유지
- 히스토리 보유 여부는 `onNavigationStateChange`의 `navState.canGoBack`을 ref로 동기화해 참조(리렌더 유발 없음)
- 포커스된 동안에만 리스너를 등록하므로 메모·설정 탭의 뒤로가기 동작은 그대로입니다
- `BackHandler`는 Android 전용이므로 `Platform.OS === "android"`에서만 등록합니다

## 관련 이슈

없음

## 변경 유형

- [ ] Feature (새로운 기능)
- [x] Fix (버그 수정)
- [ ] Chore (유지보수, 의존성)
- [ ] Refactor (코드 구조 개선)

## 테스트 방법

- `pnpm type-check` 통과
- `pnpm biome check` (변경 파일) 통과
- 실기기/에뮬레이터 검증은 이 환경에 연결된 Android 디바이스가 없어 수행하지 못했습니다. 아래 시나리오로 확인 부탁드립니다.
  1. 브라우저 탭에서 페이지 진입 → 링크 2~3회 이동 → 뒤로가기 시 웹뷰가 한 단계씩 뒤로 이동
  2. 히스토리를 모두 소진한 뒤 뒤로가기 → 기존처럼 메모 탭으로 이동
  3. 홈(빈 브라우저) 화면에서 뒤로가기 → 기존처럼 메모 탭으로 이동
  4. 메모/설정 탭에서 뒤로가기 → 기존 동작 그대로

> `source={{ uri: currentUrl }}`가 `onNavigationStateChange`로 갱신되지만, react-native-webview Android 구현(`RNCWebViewManagerImpl.loadSource`)이 현재 URL과 동일하면 `loadUrl`을 건너뛰므로 `goBack()` 이후 재로딩 루프는 발생하지 않습니다.

## 스크린샷 (해당하는 경우)

없음

## 체크리스트

- [x] 이 프로젝트의 스타일 가이드를 따랐습니다
- [x] 직접 작성한 코드를 셀프 리뷰했습니다
- [x] 이해하기 어려운 부분에 주석을 작성했습니다
- [ ] 관련 문서를 함께 수정했습니다
- [x] 새로운 경고(warning)가 발생하지 않습니다
