### PR TITLE
fix: 안드로이드에서 하이라이트 메모 입력창이 키보드에 가리던 문제 수정

### DIFF
--- a/apps/app/app/(main)/browser/_components/HighlightEditSheet.tsx
+++ b/apps/app/app/(main)/browser/_components/HighlightEditSheet.tsx
@@ -26,6 +26,7 @@ import Animated, {
 	withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useKeyboardHeight } from "@/lib/hooks/useKeyboardHeight";
 
 const SCREEN_HEIGHT = Dimensions.get("window").height;
 const SHEET_HEIGHT = SCREEN_HEIGHT * 0.5;
@@ -65,6 +66,7 @@ export function HighlightEditSheet({
 }: HighlightEditSheetProps) {
 	const insets = useSafeAreaInsets();
 	const isDark = useColorScheme() === "dark";
+	const { keyboardHeight } = useKeyboardHeight();
 	const translateY = useSharedValue(SHEET_HEIGHT);
 	const opacity = useSharedValue(0);
 	const [modalVisible, setModalVisible] = useState(false);
@@ -82,6 +84,27 @@ export function HighlightEditSheet({
 	const lastFlushedNoteRef = useRef<string | null>(null);
 
 	const visible = highlight !== null;
+
+	/**
+	 * 키보드가 화면 하단을 가리는 높이.
+	 * @description iOS는 `KeyboardAvoidingView`가 시트를 밀어 올리지만, Android는
+	 * edge-to-edge에서 창이 리사이즈되지 않아 그 동작이 먹지 않는다. 키보드 높이
+	 * (내비게이션 바 제외)에 하단 인셋을 더해 시트를 직접 밀어 올린다.
+	 */
+	const keyboardBottomInset =
+		Platform.OS === "android" && keyboardHeight > 0
+			? keyboardHeight + insets.bottom
+			: 0;
+
+	/**
+	 * 실제로 렌더할 시트 높이.
+	 * @description 키보드가 올라와 남은 영역이 시트보다 작으면 렌더 높이만 줄여
+	 * 시트 상단이 화면 밖으로 잘리지 않게 한다. 키보드가 내려가면 원래 높이로 돌아온다.
+	 */
+	const sheetHeight = Math.min(
+		SHEET_HEIGHT,
+		SCREEN_HEIGHT - keyboardBottomInset - insets.top,
+	);
 
 	useEffect(() => {
 		if (visible) {
@@ -197,7 +220,11 @@ export function HighlightEditSheet({
 					className="bg-white dark:bg-neutral-900 rounded-t-[20px]"
 					style={[
 						sheetStyle,
-						{ height: SHEET_HEIGHT, paddingBottom: insets.bottom + 16 },
+						{
+							height: sheetHeight,
+							marginBottom: keyboardBottomInset,
+							paddingBottom: (keyboardBottomInset > 0 ? 0 : insets.bottom) + 16,
+						},
 					]}
 				>
 					<View className="items-center py-2.5">


### PR DESCRIPTION
## Summary

- 인앱 브라우저에서 하이라이트를 탭해 편집 시트를 열고 "메모 남기기"를 누르면, Android에서 키보드가 입력창을 그대로 덮던 문제를 수정했습니다.
- 원인: Android 15 edge-to-edge 환경에서는 `windowSoftInputMode="adjustResize"`가 무시되어 창이 키보드만큼 줄지 않습니다. 이때 RN이 `keyboardDidShow`로 내려주는 `screenY`는 화면 하단 그대로라(`ReactRootView.checkForKeyboardEvents`) `KeyboardAvoidingView`가 여백을 만들지 못하는데, `HighlightEditSheet`는 `behavior`가 Android에서 `undefined`인 `KeyboardAvoidingView`에만 의존하고 있었습니다.
- 이미 같은 원인으로 메모 패널을 고친 커밋(b372a65)이 있고 `useKeyboardHeight` 훅도 존재했지만, 이후 추가된 하이라이트 편집 시트에는 적용되지 않은 상태였습니다. 동일한 패턴(`keyboardHeight + insets.bottom`만큼 직접 밀어 올리기 + 렌더 높이 제한)을 적용했습니다.

## 변경 내용

- `HighlightEditSheet`에서 `useKeyboardHeight`를 구독해 Android일 때만 `keyboardBottomInset`(키보드 높이 + 하단 인셋)을 계산하고, 시트에 `marginBottom`으로 적용
- 키보드가 올라와 남은 영역이 시트(화면의 50%)보다 작으면 렌더 높이만 `Math.min`으로 제한 → 시트 상단이 화면 밖으로 잘리지 않고, 키보드가 내려가면 원래 높이로 복원
- 키보드가 떠 있는 동안에는 내비게이션 바용 `paddingBottom`(`insets.bottom`)을 빼서 좁아진 세로 공간을 낭비하지 않도록 조정
- iOS 동작 경로(`KeyboardAvoidingView` `behavior="padding"`)는 그대로 두어 회귀 위험 없음

## Test plan

- [ ] Android: 인앱 브라우저에서 하이라이트 탭 → 편집 시트 → "메모 남기기" 포커스 시 입력창이 키보드 위에 완전히 보이는지
- [ ] Android: 키보드가 뜬 상태에서 시트 상단(핸들/원문 텍스트)이 잘리지 않는지
- [ ] Android: 키보드를 내리면 시트가 원래 높이(화면 50%)로 복원되는지
- [ ] Android: 메모 입력 후 배경 터치로 닫을 때 코멘트가 정상 저장되고 중복 저장되지 않는지
- [ ] Android: 색상 변경 / 하이라이트 삭제가 기존대로 동작하는지
- [ ] iOS: 기존 동작(키보드 올라올 때 시트 밀림)에 회귀가 없는지