### PR TITLE
chore: 앱 버전 1.0.8로 올림 (Play Console 제출용)

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -3,7 +3,7 @@
 		"name": "Web Memo",
 		"slug": "web-memo",
 		"owner": "guesung",
-		"version": "1.0.7",
+		"version": "1.0.8",
 		"orientation": "portrait",
 		"icon": "./assets/icon.png",
 		"scheme": "webmemo",


### PR DESCRIPTION
## 작업 내용

`apps/app/app.json`의 `version`을 `1.0.7` → `1.0.8`로 올렸습니다.

## 배경

`1.0.7`은 2026-06-23에 올린 버전입니다. 이후 아래 앱 수정들이 버전 구분 없이 나가고 있었습니다.

- `fix: Android 키보드 가림 및 값 있는 필드 토글로 숨겨지는 문제 수정` (7/27)
- `feat: 앱에 라이트/다크 테마 직접 고르는 설정 추가` (8/17)
- `fix: 앱 웹뷰에서 드래그 시 메모 자동 복사되는 동작 제거` (8/17)
- `fix: 안드로이드에서 하이라이트 메모 입력창이 키보드에 가리던 문제 수정` (8/19)

Play Console 출시를 앞두고 스토어에 노출되는 버전을 맞춥니다.

## 참고

- `versionCode` / `buildNumber`는 `eas.json`의 `appVersionSource: "remote"`에 따라 EAS가 자동 증가시키므로 건드리지 않았습니다.
- 릴리스 노트 트랙(`Update.ts` + `translation.json`)은 웹 업데이트 모달용이라 이번 앱 릴리스와 분리했습니다.
- 머지 후 Actions → **Release** 를 `app: true`로 실행합니다.

## 테스트

- `pnpm check` — 에러 없음 (기존 경고 13건만)

https://claude.ai/code/session_01JtJpDjsHd8XjUmgyHNQfUy