### PR TITLE
[DB-844] feat: 앱 릴리스 완료 후 Slack 알림 전송

### DIFF
--- a/.github/scripts/notify-app-release.sh
+++ b/.github/scripts/notify-app-release.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# 앱 릴리스(iOS/Android 빌드 + 스토어 제출) 결과를 Slack으로 알립니다.
+# .github/workflows/cd-app.yml 의 notify 잡에서 호출합니다.
+#
+# 로컬에서 그대로 돌려볼 수 있습니다(실제 run을 조회해 실제 Slack으로 보냅니다):
+#   SLACK_WEBHOOK_URL=... GH_TOKEN=$(gh auth token) BUILD_RESULT=success \
+#   GITHUB_REPOSITORY=guesung/Web-Memo GITHUB_RUN_ID=<run id> \
+#   .github/scripts/notify-app-release.sh
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?저장소를 알 수 없습니다}"
+: "${GITHUB_RUN_ID:?실행 ID를 알 수 없습니다}"
+GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+BUILD_RESULT="${BUILD_RESULT:-unknown}"
+
+if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
+  echo "::warning::SLACK_WEBHOOK_URL 시크릿이 없어 Slack 알림을 건너뜁니다"
+  exit 0
+fi
+
+# matrix 잡의 결과는 needs.build.result 하나로 합쳐져 플랫폼별 성패를 알 수 없습니다.
+# 실행 중인 run의 잡 목록을 조회해 플랫폼별 conclusion을 그대로 가져옵니다.
+jobs=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100")
+
+# 재사용 워크플로로 호출되면 잡 이름 앞에 호출한 쪽 이름이 붙으므로("앱 릴리스 / ios 빌드")
+# 정확히 일치시키지 않고 끝부분으로 찾습니다.
+describe() {
+  conclusion=$(echo "$jobs" | jq -r --arg name "$1 빌드" \
+    'first(.jobs[] | select(.name | endswith($name)) | .conclusion) // "unknown"')
+  case "$conclusion" in
+    success)   echo "✅ 빌드·제출 완료" ;;
+    failure)   echo "❌ 실패" ;;
+    cancelled) echo "⚪️ 취소됨" ;;
+    *)         echo "❔ 결과 확인 불가 ($conclusion)" ;;
+  esac
+}
+
+version=$(jq -r '.expo.version' apps/app/app.json)
+run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+if [[ "$BUILD_RESULT" == "success" ]]; then
+  headline="✅ 앱 릴리스 완료 — v$version"
+else
+  headline="❌ 앱 릴리스 실패 — v$version"
+fi
+
+body=$(printf '%s\n• iOS (TestFlight): %s\n• Android (Play 내부 테스트): %s' \
+  "*$headline*" "$(describe ios)" "$(describe android)")
+
+payload=$(jq -n --arg text "$headline" --arg body "$body" --arg url "$run_url" '{
+  text: $text,
+  blocks: [
+    { type: "section", text: { type: "mrkdwn", text: $body } },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "워크플로 실행 보기" },
+          url: $url
+        }
+      ]
+    }
+  ]
+}')
+
+curl --fail --silent --show-error \
+  -X POST -H "Content-Type: application/json" \
+  --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -96,3 +96,27 @@ jobs:
       - name: Submit to store
         if: ${{ inputs.deploy_target == 'production' }}
         run: cd apps/app && eas submit --platform ${{ matrix.platform }} --profile production --path ./${{ matrix.output }} --non-interactive
+
+  # 빌드+제출이 모두 끝난 뒤 결과를 한 번에 알립니다.
+  # 검증 빌드(deploy_target = none)는 PR마다 돌아 채널이 시끄러워지므로 알리지 않습니다.
+  notify:
+    name: Slack 알림
+    needs: build
+    # 빌드가 깨지거나 취소돼도 알려야 하므로 always()로 항상 실행합니다.
+    if: ${{ always() && inputs.deploy_target == 'production' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # 플랫폼별 잡 결과를 조회하는 데 필요합니다.
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: .github/scripts/notify-app-release.sh


### PR DESCRIPTION
## 작업 내용

앱 릴리스(`Release` 워크플로의 `app` 타깃)가 iOS/Android 빌드와 스토어 제출을 마치면 결과를 Slack으로 알립니다.

```
*✅ 앱 릴리스 완료 — v1.0.8*
• iOS (TestFlight): ✅ 빌드·제출 완료
• Android (Play 내부 테스트): ❌ 실패
[워크플로 실행 보기]
```

- 플랫폼별로 따로 보내지 않고, 두 빌드가 모두 끝난 뒤 요약 한 건만 보냅니다.
- 빌드가 깨지거나 취소돼도 알려야 하므로 `always()`로 실행합니다.
- PR마다 도는 검증 빌드(`deploy_target: none`)는 채널이 시끄러워지므로 알리지 않습니다.

## 구현 메모

**플랫폼별 성패를 어떻게 아는가** — matrix 잡의 결과는 `needs.build.result` 하나로 합쳐져 어느 플랫폼이 깨졌는지 알 수 없고, matrix `outputs`도 나중에 끝난 잡이 덮어씁니다. 그래서 실행 중인 run의 잡 목록을 조회해 개별 `conclusion`을 읽습니다(`actions: read` 권한 추가).

**스크립트 분리** — 전송 로직은 `.github/scripts/notify-app-release.sh`로 뺐습니다. 워크플로 YAML이 짧아지는 것보다, 수정할 때마다 릴리스를 돌리지 않고 로컬에서 바로 검증할 수 있다는 게 큽니다.

```bash
SLACK_WEBHOOK_URL=... GH_TOKEN=$(gh auth token) BUILD_RESULT=success \
GITHUB_REPOSITORY=guesung/Web-Memo GITHUB_RUN_ID=<run id> \
.github/scripts/notify-app-release.sh
```

## 사전 준비

`SLACK_WEBHOOK_URL` 레포 시크릿 등록 완료. 시크릿이 없어도 경고만 남기고 통과하므로 릴리스가 깨지지 않습니다.

## 확인 방법

머지 후 `Release` 워크플로를 `app` 타깃으로 실행하면 Slack에 알림이 옵니다.