### PR TITLE
fix: 앱 CD 호출부에 actions:read를 줘 워크플로 startup_failure 해소

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,13 @@ jobs:
   # PR에서는 빌드 검증만 하고(none) 제출하지 않습니다.
   cd-app:
     needs: [ci, changes]
+    # cd-app의 notify 잡은 플랫폼별 결과를 조회하려고 actions:read를 씁니다.
+    # 재사용 워크플로의 잡은 호출자가 가진 권한을 넘어설 수 없고, 이 레포의
+    # 기본 토큰 권한은 read뿐이라 호출하는 쪽에서 먼저 넓혀 줘야 합니다.
+    # 이게 없으면 워크플로가 startup_failure로 파싱 단계에서 죽습니다.
+    permissions:
+      contents: read
+      actions: read
     if: needs.changes.outputs.app == 'true'
     uses: ./.github/workflows/cd-app.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,13 @@ jobs:
   release-app:
     name: 앱 릴리스
     needs: preflight
+    # cd-app의 notify 잡은 플랫폼별 결과를 조회하려고 actions:read를 씁니다.
+    # 재사용 워크플로의 잡은 호출자가 가진 권한을 넘어설 수 없고, 이 레포의
+    # 기본 토큰 권한은 read뿐이라 호출하는 쪽에서 먼저 넓혀 줘야 합니다.
+    # 이게 없으면 워크플로가 startup_failure로 파싱 단계에서 죽습니다.
+    permissions:
+      contents: read
+      actions: read
     if: ${{ inputs.app }}
     uses: ./.github/workflows/cd-app.yml
     secrets: inherit


### PR DESCRIPTION
## 문제

PR #425에서 `cd-app.yml`에 Slack 알림(`notify`) 잡이 들어갔고, 이 잡은 플랫폼별 빌드 결과를 조회하려고 `actions: read`를 요구합니다.

그런데 **재사용 워크플로의 잡은 호출자가 가진 권한을 넘어설 수 없습니다.** 이 레포의 `default_workflow_permissions`는 read라 `actions`는 `none`이고, 호출하는 쪽에서 먼저 넓혀 주지 않으면 워크플로 전체가 파싱 단계에서 죽습니다.

```
Error calling workflow '.../cd-app.yml@6e6ff5bf'.
The nested job 'notify' is requesting 'actions: read', but is only allowed 'actions: none'.
```

로그도 annotation도 남지 않고 `startup_failure`로만 끝나서 원인이 잘 안 보입니다.

**영향 범위 — 두 군데가 동시에 막혀 있었습니다.**

- `release.yml` → 앱 릴리스 수동 실행이 시작조차 안 됨
- `ci.yml` → PR #425 머지 이후 **master CI가 통째로 안 뜸**

## 변경

두 호출부(`ci.yml`의 `cd-app`, `release.yml`의 `release-app`)에 권한을 명시합니다. 순수하게 7줄씩, 총 14줄 추가뿐입니다.

```yaml
permissions:
  contents: read
  actions: read
```

## 참고

이 커밋은 원래 #426에 있었지만, 그 PR은 E2E 수정·라벨 opt-in이 함께 묶여 있고 E2E가 실패 중이라 릴리스 복구가 묶입니다. 그래서 권한 수정만 떼어 먼저 보냅니다. #426은 이 PR 머지 후 master를 당기면 됩니다(같은 라인이라 충돌이 날 수 있으나 내용이 동일해 정리는 간단합니다).

## 확인 방법

머지 후 `Release` 워크플로를 `app` 타깃으로 실행하면 정상 시작하고, 완료 시 Slack 알림까지 옵니다.