### PR TITLE
chore: CD 워크플로 이름과 잡 id를 실제 동작에 맞게 정리

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -1,4 +1,4 @@
-name: CD - App (iOS / Android Build)
+name: CD - App (iOS / Android Build + Store Submit)
 
 on:
   workflow_call:
@@ -13,10 +13,12 @@ on:
         default: ""
 
 jobs:
-  build:
+  build-app:
     # iOS는 macOS 러너가 필수지만 Android는 ubuntu에서 돌려야 러너 과금이 절약됩니다.
     # 빌드 전 단계(체크아웃~환경변수)가 두 플랫폼 동일해 matrix로 묶고,
     # 플랫폼 전용 단계만 if로 분기합니다.
+    # 이 표시 이름은 notify-app-release.sh가 플랫폼별 결과를 찾는 데 씁니다.
+    # 바꾸면 스크립트의 매칭 문자열도 같이 고쳐야 알림이 결과를 읽습니다.
     name: ${{ matrix.platform }} 빌드
     runs-on: ${{ matrix.runner }}
     env:
@@ -101,7 +103,7 @@ jobs:
   # 검증 빌드(deploy_target = none)는 PR마다 돌아 채널이 시끄러워지므로 알리지 않습니다.
   notify:
     name: Slack 알림
-    needs: build
+    needs: build-app
     # 빌드가 깨지거나 취소돼도 알려야 하므로 always()로 항상 실행합니다.
     if: ${{ always() && inputs.deploy_target == 'production' }}
     runs-on: ubuntu-latest
@@ -118,5 +120,5 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GH_TOKEN: ${{ github.token }}
-          BUILD_RESULT: ${{ needs.build.result }}
+          BUILD_RESULT: ${{ needs['build-app'].result }}
         run: .github/scripts/notify-app-release.sh

--- a/.github/workflows/cd-extension.yml
+++ b/.github/workflows/cd-extension.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build-extension:
+    name: 확장 빌드
     runs-on: ubuntu-latest
     env:
       WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
@@ -57,7 +58,7 @@ jobs:
   upload-extension:
     needs: build-extension
     runs-on: ubuntu-latest
-    name: Upload chrome store on production release
+    name: 크롬 웹스토어 업로드
     if: ${{ inputs.deploy_target == 'production' }}
     steps:
       - name: Download Artifacts

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build-web:
+    name: 웹 빌드·배포
     runs-on: ubuntu-latest
     env:
       WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}


### PR DESCRIPTION
## 배경

`cd-*.yml`을 `release-*.yml`로 바꿀지 검토하다가, 이름이 실제 동작과 어긋난 곳이 따로 있어 그쪽을 정리합니다.

**파일명은 그대로 둡니다.** 이 워크플로들은 `deploy_target`에 따라 릴리스만 하는 게 아니라 빌드 검증(`none`)도 합니다.

| | `none` | `staging` | `production` |
|---|---|---|---|
| cd-app | 빌드 검증만 (PR) | — | 빌드 + 스토어 제출 |
| cd-web | 빌드만 | Vercel 스테이징 | Vercel 프로덕션 |
| cd-extension | 빌드 검증만 | — | 웹스토어 업로드 |

`ci.yml`이 PR 검증용으로 `none`을 넘겨 부르기 때문에 `release-app.yml`이라는 이름은 틀린 정보를 줍니다. 호출자도 `release.yml` 하나가 아니라 `ci.yml`까지 둘이라, `release-` 접두사는 호출자 하나에 종속된 이름이 됩니다.

## 변경

**cd-app** — 이름이 `(iOS / Android Build)`까지만이라 제출·알림이 빠져 있었습니다.

```diff
-name: CD - App (iOS / Android Build)
+name: CD - App (iOS / Android Build + Store Submit)
```

**잡 id 통일** — `build` → `build-app` (`build-web` / `build-extension`과 같은 규칙)

**표시 이름** — `cd-web`, `cd-extension`의 빌드 잡에 `name`이 없어 Actions UI에 잡 id가 그대로 나오고 있었습니다. `upload-extension`만 영문 장문(`Upload chrome store on production release`)이라 다른 잡과 표기가 달랐습니다.

## 놓치기 쉬웠던 것

잡 id를 바꾸면서 `notify`의 결과 참조도 같이 옮겼습니다.

```diff
-BUILD_RESULT: ${{ needs.build.result }}
+BUILD_RESULT: ${{ needs['build-app'].result }}
```

이걸 빠뜨리면 빈 값이 들어가 **알림이 항상 "❌ 실패"로 뜨는** 조용한 오류가 납니다. 하이픈이 든 잡 id는 표현식에서 뺄셈으로 읽힐 여지가 있어 대괄호 표기를 썼습니다.

matrix 잡의 표시 이름(`ios 빌드`)은 `notify-app-release.sh`가 플랫폼별 결과를 찾는 열쇠라 **일부러 그대로 뒀고**, 바꿀 때 스크립트도 같이 고쳐야 한다는 주석을 남겼습니다.

## 확인

required check가 비어 있고 ruleset도 disabled라 잡 이름 변경이 머지를 막지 않는 것을 확인했습니다. 세 파일 모두 YAML 파싱으로 검증했습니다.