### PR TITLE
test: build-app 라벨 opt-in 검증 (머지하지 않음)

### DIFF
--- a/apps/app/babel.config.js
+++ b/apps/app/babel.config.js
@@ -1,3 +1,4 @@
+// build-app 라벨 opt-in 검증용 임시 변경 (검증 후 되돌립니다)
 module.exports = (api) => {
 	api.cache(true);
 	return {


### PR DESCRIPTION
`build-app` 라벨 opt-in이 실제로 동작하는지 확인하기 위한 **임시 PR입니다. 머지하지 않고 닫습니다.**

`apps/app/babel.config.js`에 주석 한 줄을 넣어 `changes` 판정의 `app`을 `true`로 만듭니다.

## 확인할 것

| 단계 | 기대 |
|---|---|
| 라벨 없음 | `app=true`인데도 `cd-app` **skipped** |
| `build-app` 부착 | `cd-app` **실행 시작** |

잡이 시작되는 것만 확인하고 즉시 취소합니다(완주는 약 29분이라 불필요).