### PR TITLE
Refactor: 환경별 .env 파일을 커밋하고 BUILD_ENV로 선택

### DIFF
--- a/.github/workflows/cd-extension.yml
+++ b/.github/workflows/cd-extension.yml
@@ -16,7 +16,7 @@ jobs:
   build-extension:
     runs-on: ubuntu-latest
     env:
-      WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
+      BUILD_ENV: ${{ inputs.deploy_target == 'staging' && 'staging' || 'production' }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
@@ -33,11 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Setting environment variables
-        run: |
-          echo WEB_URL=${{ env.WEB_URL }} >> packages/env/.env
-          echo NODE_ENV=production >> packages/env/.env
 
       - name: Build
         env:

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -16,7 +16,7 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
     env:
-      WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
+      BUILD_ENV: ${{ inputs.deploy_target == 'staging' && 'staging' || 'production' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,10 +45,7 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Setting environment variables
-        run: |
-          echo WEB_URL=${{ env.WEB_URL }} >> packages/env/.env
-          echo NODE_ENV=production >> packages/env/.env
-          echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> apps/web/.env
+        run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> apps/web/.env
 
       - name: Vercel Pull
         run: vercel pull --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -44,16 +44,12 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
-      - name: Setting environment variables
-        run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> apps/web/.env
-
       - name: Vercel Pull
         run: vercel pull --yes --token=${{ secrets.VERCEL_TOKEN }}
 
+      # 런타임·빌드 환경 변수는 vercel pull이 받아온 Vercel 프로젝트 설정을 씁니다.
+      # 셸로 덧씌우면 등록되지 않은 시크릿이 빈 값으로 덮어쓸 수 있습니다.
       - name: Vercel Build
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: vercel build ${{ inputs.deploy_target == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy staging

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,6 @@ jobs:
   tests_e2e:
     runs-on: ubuntu-latest
     env:
-      WEB_URL: http://localhost:3000
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
@@ -67,10 +66,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Setting environment variables
-        run: |
-          echo WEB_URL=${{ env.WEB_URL }} >> packages/env/.env
-          echo NODE_ENV=development >> packages/env/.env
-          echo "${{ secrets.WEB_ENV_FILE }}" > apps/web/.env
+        run: echo "${{ secrets.WEB_ENV_FILE }}" > apps/web/.env
 
       - name: Build The Extension
         run: pnpm run build:extension

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,13 @@
 **/dist-zip
 
 # env
+# 환경별 파일은 공개돼도 되는 값(웹 URL·NODE_ENV)만 담으므로 추적합니다.
+# 비밀은 apps/web/.env(추적 제외)에 둡니다.
 .env*
 !.env.example
+!.env.development
+!.env.staging
+!.env.production
 
 # python
 **/venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,26 +304,39 @@ function Component({ lng }: { lng: Language }) {
 
 값을 어디에 둘지는 **"환경에 따라 달라지는가"**로 정합니다. 노출 여부가 아닙니다.
 
-| 위치 | 담는 것 | 읽는 쪽 |
-| --- | --- | --- |
-| `packages/env/.env` | 확장·웹이 공유하며 환경마다 다른 값 (`NODE_ENV`, `WEB_URL`) | `tsup`이 빌드 시 인라인 |
-| `apps/web/.env` | 웹에서만 쓰는 서버 시크릿 (`OPENAI_API_KEY`, `UPSTASH_*`, `SENTRY_AUTH_TOKEN`) | Next.js가 자동 로드, 서버에서만 |
-| `packages/shared/src/constants/` | 환경과 무관한 고정값 (Supabase, Sentry DSN, GA/GTM ID, OAuth 클라이언트 ID) | 그냥 import |
+| 위치 | 담는 것 | 추적 | 읽는 쪽 |
+| --- | --- | --- | --- |
+| `packages/env/.env.{development,staging,production}` | 확장·웹이 공유하며 환경마다 다른 값 (`NODE_ENV`, `WEB_URL`) | ✅ 커밋 | `tsup`이 빌드 시 인라인 |
+| `packages/env/.env` | 위 값의 로컬 오버라이드 (선택) | ❌ | 동상 |
+| `apps/web/.env` | 웹에서만 쓰는 서버 시크릿 (`OPENAI_API_KEY`, `UPSTASH_*`) | ❌ | Next.js가 자동 로드 |
+| `packages/shared/src/constants/` | 환경과 무관한 고정값 (Supabase, Sentry DSN, GA/GTM ID, OAuth) | ✅ | 그냥 import |
 
-각각 `.env.example`이 템플릿입니다.
+### 환경별 파일을 커밋하는 이유
 
-### 왜 파일이 둘인가
+담기는 값이 웹 URL과 `NODE_ENV`뿐이라 감출 것이 없습니다. 커밋해두면 클론 직후
+바로 빌드되고, 값이 시크릿 안에 숨지 않아 추적할 수 있습니다.
 
-읽는 주체가 다릅니다.
+빌드 대상은 **셸 `BUILD_ENV`**로 고릅니다 (없으면 `development`).
 
-`packages/env/.env`는 그 패키지의 `tsup`만 읽습니다. 값을 인라인한 `dist`를 만들어
-확장·pages·웹에 `CONFIG`로 공급하므로, 소비자들은 번들러가 서로 달라도 `import`만 하면
-됩니다. 이 패키지가 번들러 차이를 흡수하는 덕분에 웹은 공유 `.env`를 읽을 필요가 없습니다.
+```bash
+BUILD_ENV=production pnpm build      # .env.production
+BUILD_ENV=staging    pnpm build      # .env.staging
+pnpm dev                             # .env.development
+```
 
-`apps/web/.env`는 Next.js가 자동으로 읽습니다. 여기 담긴 값은 웹 서버에서만 쓰이므로
-공유할 이유가 없고, Next 기본 동작을 그대로 쓰면 `dotenv-cli` 같은 장치도 필요 없습니다.
+`packages/env/.env`를 만들면 환경별 파일 위에 덮어씁니다. 일부 키만 적어도 됩니다
+(`WEB_URL`만 바꾸고 `NODE_ENV`는 그대로 두는 식).
 
-### ⚠️ `packages/env/.env`의 값은 공개됩니다
+> ⚠️ 분기 기준이 **셸** 변수라는 점이 중요합니다. 예전에는 `NODE_ENV`로 파일을
+> 골랐는데 CI가 그 값을 `.env` 파일 *안에* 써넣어, 분기가 영영 뒤집히지 않고
+> `.env.production`이 유령 파일이 된 적이 있습니다. 파일 선택은 파일을 읽기 전에
+> 끝나므로 파일 안의 값으로는 바꿀 수 없습니다.
+
+`.env.staging`의 `NODE_ENV`가 `production`인 것은 의도된 것입니다. `isProduction()`이
+Sentry·Analytics 활성화와 쿠키 `secure`를 좌우하는데, 스테이징에서도 운영과 같은
+동작을 확인해야 하기 때문입니다.
+
+### ⚠️ 이 파일들의 값은 공개됩니다
 
 `packages/env/src/config.ts`가 참조하는 키는 `tsup`이 번들에 인라인하므로
 확장·웹 클라이언트에 그대로 실립니다. **서버 시크릿을 여기 추가하지 마세요.**
@@ -333,7 +346,6 @@ function Component({ lng }: { lng: Language }) {
 
 앱(`apps/app`)은 환경 변수를 쓰지 않습니다 — 필요한 값이 전부 고정값이라 상수만 읽습니다.
 Edge Functions는 Supabase 플랫폼이 주입하는 예약 변수(`SUPABASE_SERVICE_ROLE_KEY` 등)를 씁니다.
-CI에서는 워크플로가 필요한 값만 골라 두 파일을 만듭니다.
 
 빌드 플래그: `__FIREFOX__`(Firefox 전용 빌드), `__DEV__`(확장 개발 모드)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,7 @@ function Component({ lng }: { lng: Language }) {
 | --- | --- | --- | --- |
 | `packages/env/.env.{development,staging,production}` | 확장·웹이 공유하며 환경마다 다른 값 (`NODE_ENV`, `WEB_URL`) | ✅ 커밋 | `tsup`이 빌드 시 인라인 |
 | `packages/env/.env` | 위 값의 로컬 오버라이드 (선택) | ❌ | 동상 |
-| `apps/web/.env` | 웹에서만 쓰는 서버 시크릿 (`OPENAI_API_KEY`, `UPSTASH_*`) | ❌ | Next.js가 자동 로드 |
+| `apps/web/.env` | 웹에서만 쓰는 서버 시크릿 (`OPENAI_API_KEY`, `UPSTASH_*`) | ❌ | Next.js가 자동 로드 (로컬·e2e 전용) |
 | `packages/shared/src/constants/` | 환경과 무관한 고정값 (Supabase, Sentry DSN, GA/GTM ID, OAuth) | ✅ | 그냥 import |
 
 ### 환경별 파일을 커밋하는 이유
@@ -335,6 +335,15 @@ pnpm dev                             # .env.development
 `.env.staging`의 `NODE_ENV`가 `production`인 것은 의도된 것입니다. `isProduction()`이
 Sentry·Analytics 활성화와 쿠키 `secure`를 좌우하는데, 스테이징에서도 운영과 같은
 동작을 확인해야 하기 때문입니다.
+
+### 웹 배포의 런타임 값은 Vercel 프로젝트 환경변수입니다
+
+`apps/web/.env`는 로컬 개발과 e2e에서만 쓰입니다. 배포된 서버리스 함수가 읽는 값은
+Vercel 프로젝트 설정에서 오고, 워크플로는 `vercel pull`로 그것을 받아옵니다.
+
+그래서 워크플로에서 셸 환경 변수로 덧씌우지 않습니다. GitHub Secrets에 등록되지
+않은 이름을 쓰면 **빈 값이 Vercel의 실제 값을 덮어써** 조용히 망가집니다.
+런타임 값을 바꾸려면 Vercel 대시보드에서 바꿉니다.
 
 ### ⚠️ 이 파일들의 값은 공개됩니다
 

--- a/packages/env/.env.development
+++ b/packages/env/.env.development
@@ -1,0 +1,2 @@
+NODE_ENV=development
+WEB_URL=http://localhost:3000

--- a/packages/env/.env.example
+++ b/packages/env/.env.example
@@ -1,2 +1,0 @@
-NODE_ENV=
-WEB_URL=

--- a/packages/env/.env.production
+++ b/packages/env/.env.production
@@ -1,0 +1,2 @@
+NODE_ENV=production
+WEB_URL=https://web-memos.vercel.app

--- a/packages/env/.env.staging
+++ b/packages/env/.env.staging
@@ -1,0 +1,2 @@
+NODE_ENV=production
+WEB_URL=https://web-memo-staging.vercel.app

--- a/packages/env/tsup.config.ts
+++ b/packages/env/tsup.config.ts
@@ -1,11 +1,17 @@
 import dotenv from "dotenv";
 import { defineConfig } from "tsup";
 
+const BUILD_ENV = process.env.BUILD_ENV ?? "development";
+
 export default defineConfig({
 	entry: ["src/index.ts"],
 	sourcemap: true,
 	clean: true,
-	env: dotenv.config({ path: ".env" }).parsed,
+	// 추적되는 환경별 파일을 먼저 읽고, 추적되지 않는 .env로 로컬에서 덮어씁니다.
+	env: {
+		...dotenv.config({ path: `.env.${BUILD_ENV}` }).parsed,
+		...dotenv.config({ path: ".env" }).parsed,
+	},
 	dts: true,
 	format: ["esm", "cjs"],
 });

--- a/packages/env/turbo.json
+++ b/packages/env/turbo.json
@@ -4,6 +4,7 @@
 	"tasks": {
 		"ready": {
 			"inputs": ["$TURBO_DEFAULT$", ".env"],
+			"env": ["BUILD_ENV"],
 			"outputs": ["dist/**"]
 		}
 	}


### PR DESCRIPTION
> ⚠️ **Stacked PR** — base가 `master`가 아니라 #432의 브랜치입니다. 앞선 PR이 머지되면 base를 재타겟해야 합니다. (#431 → #432 → 이 PR)

## 설명

`packages/env`에 남은 값은 웹 URL과 `NODE_ENV`뿐이라 감출 것이 없습니다. 환경별 파일을 커밋해두면 클론 직후 바로 빌드되고, 값이 시크릿 안에 숨지 않아 추적할 수 있습니다.

```
packages/env/
├─ .env.development   (커밋)  localhost:3000
├─ .env.staging       (커밋)  web-memo-staging.vercel.app
├─ .env.production    (커밋)  web-memos.vercel.app
└─ .env               (추적 제외, 선택)  로컬 오버라이드
```

빌드 대상은 **셸 `BUILD_ENV`**로 고릅니다 (없으면 `development`).

```ts
const BUILD_ENV = process.env.BUILD_ENV ?? "development";
env: {
  ...dotenv.config({ path: `.env.${BUILD_ENV}` }).parsed,
  ...dotenv.config({ path: ".env" }).parsed,   // 로컬 오버라이드가 우선
}
```

### 시크릿이 세 개 없어집니다

워크플로는 `BUILD_ENV`만 넘기고 `.env` 생성 스텝이 사라집니다.

```yaml
# before (cd-extension)
env:
  WEB_URL: ${{ inputs.deploy_target == 'staging' && secrets.STAGING_WEB_URL || secrets.PROD_WEB_URL }}
...
- name: Setting environment variables
  run: |
    echo WEB_URL=${{ env.WEB_URL }} >> packages/env/.env
    echo NODE_ENV=production >> packages/env/.env

# after
env:
  BUILD_ENV: ${{ inputs.deploy_target == 'staging' && 'staging' || 'production' }}
```

→ **`PROD_WEB_URL`·`STAGING_WEB_URL`이 불필요해집니다.** (alias용 `STAGING_WEB_URL_WITHOUT_PROTOCOL`은 유지)

앞선 PR들과 합치면 `APP_ENV_FILE`, `SHARED_ENV_FILE`까지 **시크릿 4개**가 정리됩니다.

### 분기를 셸 변수로 둔 이유

예전에는 `NODE_ENV`로 파일을 골랐는데 CI가 그 값을 **`.env` 파일 안에** 써넣어, 분기가 영영 뒤집히지 않고 `.env.production`이 유령 파일이 됐습니다. 파일 선택은 파일을 읽기 전에 끝나므로 파일 안의 값으로는 바꿀 수 없습니다. `BUILD_ENV`를 셸로 넘겨 같은 함정을 피합니다.

turbo `ready` 태스크의 `env`에 `BUILD_ENV`를 선언해, 환경이 다르면 캐시도 갈리게 했습니다.

### `.env.staging`의 `NODE_ENV`가 `production`인 이유

의도된 것입니다. `isProduction()`이 Sentry·Analytics 활성화와 쿠키 `secure`를 좌우하는데, 현재 CI도 스테이징에 `production`을 넣고 있어 **동작을 그대로 유지**했습니다. 스테이징에서 이 값을 바꾸는 것은 배포 동작 변경이라 별도로 판단해야 합니다.

## 검증

| 조건 | 결과 |
| --- | --- |
| `BUILD_ENV=production` | `webUrl: "https://web-memos.vercel.app"` |
| `BUILD_ENV=staging` | `webUrl: "https://web-memo-staging.vercel.app"`, `nodeEnv: "production"` |
| 미지정 | `webUrl: "http://localhost:3000"` |
| `.env`에 `WEB_URL`만 지정 | `WEB_URL`만 덮이고 `NODE_ENV`는 환경별 파일 값 유지 |

`pnpm type-check` 14/14 통과.

## 변경 유형

- [ ] Feature (새로운 기능)
- [ ] Fix (버그 수정)
- [ ] Chore (유지보수, 의존성)
- [x] Refactor (코드 구조 개선)

## 이번 PR과 무관하게 발견한 것 ⚠️

**운영에서 OpenAI rate limit이 동작하지 않고 있습니다.**

`UPSTASH_REDIS_REST_URL`·`UPSTASH_REDIS_REST_TOKEN`이 Vercel 환경변수에도, 워크플로에도 없습니다. `ratelimit.ts`는 값이 없으면 조용히 비활성화됩니다.

```ts
const ratelimit = isRateLimitEnabled ? new Ratelimit({...}) : null;
export async function checkRateLimit(ip) {
  if (!ratelimit) return { success: true };   // 항상 통과
}
```

에러도 로그도 없어 드러나지 않습니다. Vercel 대시보드에 두 값을 넣으면 살아납니다.

## 체크리스트

- [x] 이 프로젝트의 스타일 가이드를 따랐습니다
- [x] 직접 작성한 코드를 셀프 리뷰했습니다
- [x] 이해하기 어려운 부분에 주석을 작성했습니다
- [x] 관련 문서를 함께 수정했습니다 (AGENTS.md)
- [x] 새로운 경고(warning)가 발생하지 않습니다

https://claude.ai/code/session_01T2PNz6sJYX7GMAeHtsizp2
