### PR TITLE
[DB-860] chore: Orca 워크스페이스 훅으로 노션 작업카드 자동 생성

### DIFF
--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,15 @@
+# Orca 워크스페이스 훅.
+#
+# 워크스페이스를 만들면 노션 "문제 해결 DB"에 작업카드가 생기고,
+# 워크스페이스를 지우면 그 카드가 "완료"로 넘어간다.
+#
+# 로직과 노션 토큰은 레포 밖(~/.orca/)에 있다. 훅 스크립트가 없는 머신에서는
+# 아무 일도 일어나지 않는다.
+scripts:
+  setup: |
+    hook="$HOME/.orca/hooks/notion-workcard.sh"
+    if [ -x "$hook" ]; then "$hook" create; fi
+
+  archive: |
+    hook="$HOME/.orca/hooks/notion-workcard.sh"
+    if [ -x "$hook" ]; then "$hook" archive; fi


### PR DESCRIPTION
## 개요

Orca에서 워크스페이스를 만들 때마다 노션 "문제 해결 DB"에 작업카드를 손으로 만들고 있었다. Orca가 워크스페이스 생성/삭제 시점에 훅을 돌려주므로 그 자리에 붙였다.

## 작업 사항

- `orca.yaml` 추가 — 워크스페이스 생성 시 노션 작업카드를 만들고, 삭제 시 카드를 "완료"로 넘긴다

## 참고

- Orca는 `orca.yaml`을 원본 레포가 아니라 **새 워크스페이스 체크아웃**에서 읽는다(`getEffectiveHooks(repo, worktreePath)`). 그래서 이 파일은 커밋되어야 훅이 걸린다.
- 로직과 노션 토큰은 레포 밖(`~/.orca/`)에 있고 여기서는 호출만 한다. 훅 스크립트가 없는 머신에서는 조용히 넘어간다.

https://claude.ai/code/session_0174z1D84Rhqfq4tVcJ99vFq