### PR TITLE
refactor: 환경 분기를 NODE_ENV에서 BUILD_ENV로 단일화

### DIFF
--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -17,7 +17,10 @@ jobs:
     name: 웹 빌드·배포
     runs-on: ubuntu-latest
     env:
-      BUILD_ENV: ${{ inputs.deploy_target == 'staging' && 'staging' || 'production' }}
+      # 아래 Vercel Pull·Build와 같은 기준(== 'production')으로 판정해야 합니다.
+      # deploy_target은 none·staging·production 셋인데 기준이 갈리면 none이 양쪽에서
+      # 다른 쪽으로 떨어져, 상수는 production인데 Vercel 값은 Preview인 조합이 됩니다.
+      BUILD_ENV: ${{ inputs.deploy_target == 'production' && 'production' || 'staging' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,7 @@ function Component({ lng }: { lng: Language }) {
 
 | 위치 | 담는 것 | 추적 |
 | --- | --- | --- |
-| `packages/env/.env.{development,staging,production}` | 확장·웹이 공유하며 환경마다 다른 값 (`NODE_ENV`, `WEB_URL`) | ✅ 커밋 |
+| `packages/env/.env.{development,staging,production}` | 확장·웹이 공유하며 환경마다 다른 값 (`WEB_URL`) | ✅ 커밋 |
 | `packages/env/.env` | 위 값의 로컬 오버라이드 (선택) | ❌ |
 | `apps/web/.env` | 웹에서만 쓰는 서버 시크릿 (`OPENAI_API_KEY`, `UPSTASH_*`) | ❌ |
 | Vercel 프로젝트 환경변수 | 배포된 웹의 런타임 값 | — |
@@ -343,6 +343,12 @@ BUILD_ENV=production pnpm build      # .env.production
 BUILD_ENV=staging    pnpm build      # .env.staging
 pnpm dev                             # .env.development
 ```
+
+이 값은 파일 선택에만 쓰이지 않고 번들에도 인라인됩니다. 코드에서 환경을 분기할
+때는 `CONFIG.buildEnv`(`"development" | "staging" | "production"`)를 쓰고,
+`NODE_ENV`로 판단하지 마세요 — Next·Vite가 자기 값으로 치환하는 이름이라 staging과
+production을 구분하지 못합니다. `isProduction()`은 `buildEnv !== "development"`라
+스테이징에서도 운영과 같이 동작합니다.
 
 작업할 때 반드시 지켜야 하는 것 세 가지입니다.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -30,12 +30,14 @@
 
 ## 1. `packages/env` — 확장·웹이 공유하는 환경별 값
 
-현재 담긴 값은 두 개뿐입니다.
+현재 파일에 담긴 값은 `WEB_URL` 하나뿐입니다.
 
 | 키 | development | staging | production |
 | --- | --- | --- | --- |
-| `NODE_ENV` | `development` | `production` | `production` |
 | `WEB_URL` | `http://localhost:3000` | `https://web-memo-staging.vercel.app` | `https://web-memos.vercel.app` |
+
+여기에 더해 `tsup`이 셸 `BUILD_ENV`를 번들에 함께 인라인하므로, 코드에서는
+`CONFIG.buildEnv`로 `"development" | "staging" | "production"`을 읽을 수 있습니다.
 
 `packages/env/src/config.ts`가 이 값을 읽어 `CONFIG` 객체로 내보내고, 소비하는 쪽은
 `import { CONFIG } from "@web-memo/env"`로 씁니다. `getSafeConfig`가 `undefined`를
@@ -44,7 +46,7 @@
 
 ### 환경별 파일을 커밋하는 이유
 
-담기는 값이 웹 URL과 `NODE_ENV`뿐이라 감출 것이 없습니다. 커밋해두면 클론 직후
+담기는 값이 웹 URL뿐이라 감출 것이 없습니다. 커밋해두면 클론 직후
 바로 빌드되고, 값이 시크릿 안에 숨지 않아 히스토리로 추적할 수 있습니다.
 
 `.gitignore`는 `.env*`를 무시한 뒤 이 세 파일만 부정 패턴으로 되살립니다. 이때
@@ -61,7 +63,8 @@ pnpm dev                             # .env.development (기본값)
 
 `packages/env/tsup.config.ts`가 `BUILD_ENV`로 파일을 고른 뒤, 추적되지 않는
 `packages/env/.env`를 그 위에 덮어씁니다. 로컬 오버라이드는 일부 키만 적어도
-됩니다 (`WEB_URL`만 바꾸고 `NODE_ENV`는 그대로 두는 식).
+됩니다. 단 `BUILD_ENV`는 셸 값이 항상 이깁니다 — `.env` 안에 적어도 파일 선택은
+이미 끝난 뒤라, 파일 내용으로 분기를 뒤집는 착각을 막기 위해 마지막에 덮어씁니다.
 
 `packages/env/turbo.json`의 `ready` 태스크가 `env: ["BUILD_ENV"]`를 선언하므로
 환경별로 캐시가 갈립니다. 이게 없으면 staging 빌드가 production 캐시를 재사용합니다.
@@ -71,10 +74,24 @@ pnpm dev                             # .env.development (기본값)
 > 파일 선택은 파일을 읽기 전에 끝나므로 파일 안의 값으로는 분기를 뒤집을 수 없고,
 > 결과적으로 `.env.production`이 한 번도 선택되지 않는 유령 파일이 됐습니다.
 
-### `.env.staging`의 `NODE_ENV`가 `production`인 것은 의도된 것입니다
+### 환경 분기는 `CONFIG.buildEnv` 하나로 합니다
 
-`isProduction()`이 Sentry·Analytics 활성화와 쿠키 `secure` 플래그를 좌우합니다.
-스테이징에서도 운영과 같은 동작을 확인해야 하므로 `production`을 넣습니다.
+`isProduction()`이 Sentry·Analytics 활성화와 쿠키 `secure` 플래그를 좌우하는데,
+스테이징에서도 운영과 같은 동작을 확인해야 하므로 **개발만 제외**하는 정의입니다.
+
+```ts
+export const isProduction = () => CONFIG.buildEnv !== "development";
+```
+
+> 예전에는 이 판단을 `NODE_ENV`로 했고, 그래서 `.env.staging`에 `NODE_ENV=production`을
+> 적어야 했습니다. 그러면 staging과 production이 코드에서 **같은 값**이 되어 구분할
+> 수단이 사라집니다. 실제로 `config.ts`의 타입에는 `"staging"`이 있었지만 어떤 `.env`
+> 파일에도 그 값이 없어, 런타임에 도달할 수 없는 타입이었습니다.
+>
+> 이름도 겹쳤습니다. `NODE_ENV`는 Next·Vite가 자기 값으로 치환하는 이름이라, 같은
+> 식별자에 공급처가 둘이었습니다. `BUILD_ENV`로 바꾸면서 이 충돌도 사라졌습니다.
+> 툴체인이 쓰는 `process.env.NODE_ENV`(`next.config.mjs`의 `removeConsole` 등)는
+> 그대로 두면 됩니다 — `packages/env`와 무관하게 각 도구가 알아서 넣습니다.
 
 ### ⚠️ 여기 값은 공개됩니다
 
@@ -111,7 +128,41 @@ Vercel 프로젝트 설정에서 옵니다.
 
 등록해야 하는 값은 `apps/web/.env.example`의 세 개(`OPENAI_API_KEY`,
 `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`)와, 소스맵 업로드에 쓰는
-`SENTRY_AUTH_TOKEN`입니다. 변경은 Vercel 대시보드에서 합니다.
+`SENTRY_AUTH_TOKEN`, 그리고 빌드 시스템 플래그 `ENABLE_EXPERIMENTAL_COREPACK`입니다.
+변경은 Vercel 대시보드나 `vercel env` CLI로 합니다.
+
+| 키 | 환경 | 없으면 생기는 일 |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | Production·Preview·Development | AI 기능 전체가 실패 |
+| `UPSTASH_REDIS_REST_URL` | 동상 | 레이트 리밋이 **조용히 꺼짐** |
+| `UPSTASH_REDIS_REST_TOKEN` | 동상 | 동상 |
+| `SENTRY_AUTH_TOKEN` | Production·Preview | 소스맵 업로드가 **조용히 실패** |
+| `ENABLE_EXPERIMENTAL_COREPACK` | 전 환경 | corepack이 꺼져 `packageManager`의 pnpm 버전이 무시됨 |
+
+`ENABLE_EXPERIMENTAL_COREPACK`은 코드가 읽는 값이 아니라 Vercel 빌드 시스템이 보는
+플래그입니다. 코드에서 grep해도 나오지 않으므로 "안 쓰는 값"으로 오인하기 쉽지만,
+루트 `package.json`의 `packageManager` 필드를 따르게 하는 값이라 지우면 빌드가 쓰는
+pnpm 버전이 바뀝니다.
+
+### 여기에 등록하지 않는 값
+
+Supabase URL·anon key, Sentry DSN, `WEB_URL`은 **Vercel에 두지 않습니다.** 각각
+`packages/shared`의 상수와 `packages/env`의 커밋된 `.env` 파일에서 옵니다. Vercel에
+같은 이름으로 등록해도 코드가 읽지 않으므로 값만 두 곳으로 갈라져 혼란을 만듭니다.
+
+> 실제로 이 이름들이 리팩토링 이후에도 Vercel에 남아 있다가 2026-08-23에 정리됐습니다
+> (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_URL`,
+> `SUPABASE_ANON_KEY`, `SENTRY_DSN`, `WEB_URL`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`,
+> `GOOGLE_PRIVATE_KEY`, `MAKE_WEBHOOK_NOTION_API` 9개).
+> **코드에서 `process.env` 참조를 지울 때 Vercel 쪽 값도 같이 지워야 합니다.**
+> 남겨둬도 빌드가 깨지지 않아 몇 년이든 방치됩니다.
+
+현황 확인은 아래로 합니다. 값은 암호화돼 있어 이름·환경만 보입니다.
+
+```bash
+vercel link                      # 최초 1회
+vercel env ls production
+```
 
 ### 셸 환경 변수로 덧씌우지 않습니다
 
@@ -190,9 +241,11 @@ Protocol로 직접 이벤트를 보내는 현재 구조상 이미 번들에 인�
 같은 이름이지만 공급처가 둘로 갈립니다.
 
 - **확장**: `cd-extension.yml`의 Build 스텝이 `${{ secrets.SENTRY_AUTH_TOKEN }}`을
-  셸 환경 변수로 넘깁니다. → GitHub Secrets에 등록 (2026-08-23 등록 완료)
+  셸 환경 변수로 넘깁니다. → GitHub Secrets에 등록
 - **웹**: 셸로 받지 않고 `vercel pull`이 가져오는 Vercel 프로젝트 환경변수에
-  의존합니다. → Vercel 대시보드에 등록
+  의존합니다. → Vercel 프로젝트 환경변수(Production·Preview)에 등록
+
+둘 다 2026-08-23에 등록을 마쳤습니다.
 
 그래서 **양쪽 모두에 등록해야** 소스맵이 올라갑니다. 한쪽만 있으면 그쪽만 동작하고
 다른 쪽은 조용히 실패합니다. 소스맵 업로드는 실패해도 빌드가 통과하므로 드러나지
@@ -237,7 +290,7 @@ gitignore 대상이라 EAS 샌드박스에 복사되지 않아 iOS 빌드가 깨
 
 | 이름 | 의미 | 설정하는 곳 |
 | --- | --- | --- |
-| `BUILD_ENV` | `packages/env`가 읽을 `.env.{환경}` 선택 | 셸 / 워크플로 `env` |
+| `BUILD_ENV` | `.env.{환경}` 선택 + `CONFIG.buildEnv`로 번들에 인라인 | 셸 / 워크플로 `env` |
 | `__FIREFOX__` | Firefox 전용 빌드 (manifest 분기) | 빌드 스크립트 |
 | `__DEV__` | 확장 개발 모드 (HMR·소스맵) | `packages/vite-config` |
 | `ANALYZE` | Next.js 번들 분석 활성화 | 로컬에서 수동 |

--- a/packages/env/.env.development
+++ b/packages/env/.env.development
@@ -1,2 +1,1 @@
-NODE_ENV=development
 WEB_URL=http://localhost:3000

--- a/packages/env/.env.production
+++ b/packages/env/.env.production
@@ -1,2 +1,1 @@
-NODE_ENV=production
 WEB_URL=https://web-memos.vercel.app

--- a/packages/env/.env.staging
+++ b/packages/env/.env.staging
@@ -1,2 +1,1 @@
-NODE_ENV=production
 WEB_URL=https://web-memo-staging.vercel.app

--- a/packages/env/src/config.ts
+++ b/packages/env/src/config.ts
@@ -8,7 +8,9 @@ export const getSafeConfig = (
 
 export const CONFIG = {
 	webUrl: getSafeConfig("WEB_URL", process.env.WEB_URL),
-	nodeEnv: getSafeConfig("NODE_ENV", process.env.NODE_ENV) as
+	// 빌드 대상 환경. tsup이 셸 BUILD_ENV를 그대로 번들에 인라인합니다.
+	// 툴체인이 자동으로 넣는 NODE_ENV와 달리 staging과 production을 구분합니다.
+	buildEnv: getSafeConfig("BUILD_ENV", process.env.BUILD_ENV) as
 		| "development"
 		| "staging"
 		| "production",

--- a/packages/env/tsup.config.ts
+++ b/packages/env/tsup.config.ts
@@ -8,9 +8,12 @@ export default defineConfig({
 	sourcemap: true,
 	clean: true,
 	// 추적되는 환경별 파일을 먼저 읽고, 추적되지 않는 .env로 로컬에서 덮어씁니다.
+	// BUILD_ENV는 맨 뒤에 둡니다. 파일 안의 값이 이기면 파일 선택 기준을 파일
+	// 내용으로 뒤집으려는 시도가 다시 생기는데, 선택은 읽기 전에 끝나 있습니다.
 	env: {
 		...dotenv.config({ path: `.env.${BUILD_ENV}` }).parsed,
 		...dotenv.config({ path: ".env" }).parsed,
+		BUILD_ENV,
 	},
 	dts: true,
 	format: ["esm", "cjs"],

--- a/packages/shared/src/utils/Environment.ts
+++ b/packages/shared/src/utils/Environment.ts
@@ -3,7 +3,8 @@ import { CONFIG } from "@web-memo/env";
 export const isMac = () =>
 	typeof navigator !== "undefined" &&
 	/Mac|iPhone|iPad|iPod/.test(navigator.platform);
-export const isProduction = () => CONFIG.nodeEnv === "production";
+// staging도 운영과 같이 동작해야 하므로(Sentry·Analytics·쿠키 secure) 개발만 제외합니다.
+export const isProduction = () => CONFIG.buildEnv !== "development";
 export const isExtension = () =>
 	typeof chrome !== "undefined" && typeof chrome.management !== "undefined";
 export function isServer() {


### PR DESCRIPTION
> **Stacked PR** — base는 #434(`guesung/문서-최신화`)입니다. #434가 머지된 뒤 base를 `master`로 바꿔 주세요.

## 설명

`packages/env`가 담고 있던 `NODE_ENV`를 없애고, **파일 선택에 이미 쓰고 있던 셸 `BUILD_ENV`를 그대로 번들에 인라인**해 `CONFIG.buildEnv`로 노출합니다.

`NODE_ENV`의 실제 소비처는 `isProduction()` 하나뿐이었습니다(`packages/shared/src/utils/Environment.ts`). 그 하나를 위해 세 가지 문제를 안고 있었습니다.

### 1. staging과 production을 구분할 수 없었다

`isProduction()`이 Sentry·Analytics·쿠키 `secure`를 좌우하는데 스테이징에서도 켜져야 해서, `.env.staging`에 `NODE_ENV=production`을 적었습니다. 그 결과 두 환경이 코드에서 **같은 값**이 됩니다. `BUILD_ENV`는 그 정보를 갖고 있었지만 번들에 실리지 않았습니다.

### 2. 타입에 도달 불가능한 값이 있었다

```ts
nodeEnv: getSafeConfig("NODE_ENV", process.env.NODE_ENV) as
  | "development" | "staging" | "production",   // "staging"은 어떤 .env에도 없음
```

세 `.env` 파일의 값은 `development` / `production` / `production`입니다. `"staging"`은 런타임에 절대 나오지 않는 타입이었습니다.

### 3. 같은 이름에 공급처가 둘이었다

`tsup`이 `packages/env`의 `NODE_ENV`를 인라인하는데, Next·Vite도 같은 이름을 **자기 값으로** 치환합니다. 지금까지 값이 일치한 것은 우연입니다.

## 변경 내용

| 파일 | 변경 |
| --- | --- |
| `packages/env/.env.{development,staging,production}` | `NODE_ENV` 줄 제거 (남는 값은 `WEB_URL` 하나) |
| `packages/env/tsup.config.ts` | `env`에 `BUILD_ENV` 주입 |
| `packages/env/src/config.ts` | `nodeEnv` → `buildEnv` |
| `packages/shared/src/utils/Environment.ts` | `isProduction = () => CONFIG.buildEnv !== "development"` |

**동작은 그대로 보존됩니다.**

| `BUILD_ENV` | 이전 `isProduction()` | 이후 |
| --- | --- | --- |
| `development` | `"development" === "production"` → `false` | `"development" !== "development"` → `false` |
| `staging` | `"production" === "production"` → `true` | `"staging" !== "development"` → `true` |
| `production` | `true` | `true` |

`tsup`의 `env`에서 `BUILD_ENV`를 **맨 뒤**에 둬 셸 값이 `.env` 파일 값을 항상 이기게 했습니다. 파일 안의 값이 이기면 #431에서 겪은 "파일 선택 기준을 파일 내용으로 뒤집으려는" 함정이 다시 생깁니다 — 선택은 파일을 읽기 전에 끝나 있습니다.

## 덤: `cd-web.yml`의 판정 기준 불일치도 고쳤습니다

리뷰 중 발견한 기존 버그입니다. 같은 잡 안의 삼항연산자 세 개가 **서로 다른 기준**을 쓰고 있었습니다 — `BUILD_ENV`만 `== 'staging'`으로, `vercel pull`·`build`는 `== 'production'`으로 판정합니다. `deploy_target` 값은 `none`·`staging`·`production` 셋인데 기준이 둘이라, `none`이 양쪽에서 다른 방향으로 떨어졌습니다.

| `deploy_target` | `BUILD_ENV` | `vercel pull` | `vercel build` |
| --- | --- | --- | --- |
| `production` | production | production | `--prod` |
| `staging` | staging | preview | — |
| **`none`** (수정 전) | **production** ⚠️ | preview | — |
| **`none`** (수정 후) | staging | preview | — |

`none`은 ci.yml이 PR과 master push에서 넘기는 값입니다. 그래서 **모든 PR과 master push의 웹 빌드가 "production 상수 + Preview 시크릿"이라는 실존하지 않는 조합으로 검증**되고 있었습니다 — `WEB_URL`이 `web-memos.vercel.app`인 채로 Preview 환경 값과 섞입니다. 배포까지 가지 않아 사용자 피해는 없었지만, 검증이 실제 배포 조합을 대표하지 못했습니다.

기준을 `== 'production'`으로 통일해 `none`을 `staging`과 같이 묶었습니다. **배포 동작은 바뀌지 않습니다** — 배포 스텝의 `if` 조건은 건드리지 않았고, 웹 프로덕션은 지금처럼 `release.yml` 수동 실행으로만 나갑니다.

`NODE_ENV`였을 때도 동일하게 어긋나 있었습니다(`.env.production`이 선택됐으므로). 값이 `CONFIG.buildEnv`로 드러나면서 눈에 띈 것뿐입니다.

## 검증

```
BUILD_ENV=staging → 확장 번들에 getSafeConfig("BUILD_ENV","staging") 인라인 확인
                    (이전 구조에서는 나올 수 없던 값)
packages/env 유래 NODE_ENV 참조: 0건
CONFIG.* 접근 키 전수 조회: buildEnv, webUrl — 둘 다 정의됨
```

- [x] `development` / `staging` / `production` + 기본값(미지정) 네 경우 모두 `tsup` 산출물의 인라인 값 대조
- [x] `pnpm type-check` 14/14 통과
- [x] `pnpm check` (Biome) 통과 — 수정한 파일에 경고 없음
- [x] `BUILD_ENV=staging pnpm build:extension` 8/8 성공, 번들에 staging URL·`buildEnv` 반영 확인
- [x] `BUILD_ENV=staging pnpm build:web` 3/3 성공

> 타입체크만으로는 부족합니다. 설정 객체에서 키를 지워도 `.js`/`.mjs` 쪽 참조는 `tsc`가 잡지 못하므로, `nodeEnv`와 `CONFIG.` 접근 키를 grep으로 따로 전수 확인했습니다.

## 손대지 않은 것

툴체인이 자동으로 넣는 `process.env.NODE_ENV`는 `packages/env`와 무관하므로 그대로 뒀습니다.

- `apps/web/next.config.mjs` (`removeConsole`)
- `apps/web/src/modules/i18n/util.client.ts` (쿠키 `secure`)
- `packages/vite-config/lib/withPageConfig.mjs` (`isDev`로 직접 치환)
- `apps/app/eas.json` (EAS 빌드 환경)

`isStaging()`은 지금 쓰는 곳이 없어 만들지 않았습니다. 필요해지면 `CONFIG.buildEnv`로 바로 쓸 수 있습니다.

`cd-extension.yml`은 같은 형태의 삼항연산자를 갖고 있지만 그대로 뒀습니다. 확장은 Vercel과 무관해 짝을 맞출 상대가 없고, `staging`으로 호출하는 곳이 어디에도 없어(ci.yml은 `none` 하드코딩, release.yml은 `production`) 실질적으로 항상 `production`입니다. 정리한다면 별도 PR이 맞다고 봤습니다.

## 주입 지점

`BUILD_ENV`는 **셸에서만** 들어옵니다. `tsup.config.ts`의 `process.env.BUILD_ENV ?? "development"`가 유일한 진입점입니다.

| 경로 | 값 | 비고 |
| --- | --- | --- |
| `cd-web.yml` job `env:` | `production` \| `staging` | 이 PR에서 기준 통일 |
| `cd-extension.yml` job `env:` | `production` \| `staging` | |
| `e2e.yml` | 없음 → `development` | `playwright.config.ts`가 `localhost:3000`을 쓰므로 `.env.development`와 짝이 맞음 |
| 로컬 `pnpm dev` / `pnpm build` | 없음 → `development` | |
| Vercel Git 자동 배포 | 없음 | 프로젝트의 `commandForIgnoringBuildStep: 'exit 0'`으로 **항상 스킵**됨 (0ms Canceled). 실제 빌드는 Actions의 `vercel build --prebuilt`뿐 |

turbo가 `strict` env 모드로 도는 것도 확인했습니다. `packages/env/turbo.json`의 `env: ["BUILD_ENV"]` 선언이 통로를 열어주고, 환경별로 캐시가 정확히 갈립니다.

```
BUILD_ENV=development → 856340c9267c2ec0
BUILD_ENV=staging     → 7d398fa7637aa339
BUILD_ENV=production  → db1ca534ad44ddbc
```

## 관련 이슈

없음 (#431, #434 후속)

## 변경 유형

- [ ] Feature (새로운 기능)
- [ ] Fix (버그 수정)
- [ ] Chore (유지보수, 의존성)
- [x] Refactor (동작 변경 없는 구조 개선)

## 리뷰 시 봐주셨으면 하는 것

- `isProduction()`의 정의가 `!== "development"`인 것이 읽기에 자연스러운지. 이름과 의미가 살짝 어긋나지만(스테이징도 true), 기존 동작을 그대로 옮기는 쪽을 택했습니다. `isNotDevelopment()` 같은 이름이 낫다고 보시면 바꾸겠습니다.
- `tsup`에서 `BUILD_ENV`를 스프레드 **뒤**에 둔 선택 — 로컬 `.env`로 `BUILD_ENV`를 덮을 수 없게 됩니다. 의도한 제약입니다.

## 체크리스트

- [x] 이 프로젝트의 스타일 가이드를 따랐습니다
- [x] 직접 작성한 내용을 셀프 리뷰했습니다
- [x] 로컬에서 빌드·타입체크·린트를 모두 확인했습니다
- [x] 관련 문서를 함께 수정했습니다 (`AGENTS.md`, `docs/environment-variables.md`)

https://claude.ai/code/session_012oVUYPQWo4iTPTJQozR9Hd
