### PR TITLE
fix: 폴더블을 접거나 펴면 하단 탭바가 사라지던 문제 수정

### DIFF
--- a/apps/app/app/(main)/_components/CustomTabBar.tsx
+++ b/apps/app/app/(main)/_components/CustomTabBar.tsx
@@ -69,9 +69,17 @@ export function CustomTabBar({
 			<View
 				className="flex-row bg-white dark:bg-neutral-900 border-t border-border dark:border-neutral-800 pt-2"
 				style={{ paddingBottom: insets.bottom }}
+				// 폴더블을 접거나 펴면 액티비티 재생성 없이 레이아웃만 다시 잡혀 inset과 바 높이가 바뀐다.
+				// 최초 한 번만 기록하면 옛 높이 기준으로 visibleHeight가 0에 고정되어 탭바가 사라지므로,
+				// 높이가 바뀔 때마다 갱신하고 스크롤 숨김 오프셋도 되돌려 탭바를 다시 보인다.
 				onLayout={(e) => {
-					if (barHeight.value === 0) {
-						barHeight.value = e.nativeEvent.layout.height;
+					const nextHeight = e.nativeEvent.layout.height;
+					if (nextHeight === barHeight.value) return;
+
+					const hadHeight = barHeight.value !== 0;
+					barHeight.value = nextHeight;
+					if (hadHeight) {
+						tabBarTranslateY.value = 0;
 					}
 				}}
 			>


### PR DESCRIPTION
## Summary
- `CustomTabBar`가 탭바 높이를 최초 `onLayout` 한 번만 기록해, 폴더블을 접거나 펴서 inset·높이가 바뀌어도 옛 값으로 `visibleHeight`를 계산했다. 브라우저 탭에서 숨김 오프셋이 옛 높이 기준으로 남으면 `visibleHeight`가 0에 고정되어 탭바가 사라졌다.
- 높이가 바뀔 때마다 갱신하고, 바뀐 경우 `tabBarTranslateY`를 0으로 되돌려 탭바를 다시 보인다. 기존 높이와 같으면 아무것도 하지 않아 스크롤 숨김 동작은 그대로다.

## Test plan
- [x] biome, `turbo type-check --filter=@web-memo/app` 통과
- [ ] 폴더블 실기기: 펼친 상태에서 브라우저 탭 스크롤로 탭바 숨김 → 접기 → 탭바가 다시 보이는지
- [ ] 접은 상태로 시작 → 펼치기 → 탭바가 잘리지 않는지
- [ ] 일반 폰: 브라우저 스크롤 숨김/표시 회귀 없음

https://claude.ai/code/session_01VcMdwHgKJ5UToFQwBdamPn